### PR TITLE
Make show.fitCallbacks and show.history group certain metrics together

### DIFF
--- a/demos/mnist/index.html
+++ b/demos/mnist/index.html
@@ -218,7 +218,7 @@
           return model.fit(trainXs, trainYs, {
             batchSize: BATCH_SIZE,
             validationData: [testXs, testYs],
-            epochs: 2,
+            epochs: 10,
             shuffle: true,
             callbacks: fitCallbacks
           });

--- a/demos/mnist/index.html
+++ b/demos/mnist/index.html
@@ -55,9 +55,12 @@
 
     <section>
       <p>
-        tfjs-vis is a small set of visualization utilities to make it easier to understand what is going on with your tfjs models.
-        It is designed in a way to work along side regular web apps. This page will use some of the features of tfjs to illustrate
-        what is going on with a convolutional model that will be trained (in the browser) to recognize handwritten digits.
+        tfjs-vis is a small set of visualization utilities to make it easier to understand what is going on with your
+        tfjs models.
+        It is designed in a way to work along side regular web apps. This page will use some of the features of tfjs to
+        illustrate
+        what is going on with a convolutional model that will be trained (in the browser) to recognize handwritten
+        digits.
       </p>
 
       <p>
@@ -75,14 +78,17 @@
     <section>
       <h2>The Visor</h2>
       <p>
-        Let's take a look at the first. Calling <code>tfvis.visor()</code> will create a visor if it doesn't exist or return
+        Let's take a look at the first. Calling <code>tfvis.visor()</code> will create a visor if it doesn't exist or
+        return
         the existing one. Click the button below to show the
         <em>visor.</em>
       </p>
       <button id='show-visor'>Show Visor</button>
       <p>
-        Notice the panel that is now displayed on the right. It hovers over your pages content and shouldn't disturb the flow of
-        your page's DOM Elements. You can see a few controls for showing or hiding the visor, but by default it also supports
+        Notice the panel that is now displayed on the right. It hovers over your pages content and shouldn't disturb
+        the flow of
+        your page's DOM Elements. You can see a few controls for showing or hiding the visor, but by default it also
+        supports
         the following keyboard shortcuts:
         <ul>
           <li>
@@ -103,8 +109,10 @@
       </p>
       <button id='make-first-surface'>Make a surface</button>
       <p>
-        To create a surface we must give is a name, we can also optionally specify a tab name that the surface should be put on.
-        <code>visor().surface()</code> allows us to create a surface if it doesn't exist or fetch it if it does. This API
+        To create a surface we must give is a name, we can also optionally specify a tab name that the surface should
+        be put on.
+        <code>visor().surface()</code> allows us to create a surface if it doesn't exist or fetch it if it does. This
+        API
         returns an object that has a pointer to 3 DOM elements:
         <ul>
           <li>
@@ -121,7 +129,8 @@
     <section>
       <h2>Our Data</h2>
       <p>
-        We will use the MNIST database as our training set, it is comprised of a set of about 60k images of handwritten digits, all
+        We will use the MNIST database as our training set, it is comprised of a set of about 60k images of handwritten
+        digits, all
         cropped to 28x28 px. Lets take a look at a few examples, we'll use the surface we created earlier.
       </p>
       <button id='load-data'>Load Data</button>
@@ -129,8 +138,10 @@
       <button id='show-examples' disabled>Show Example Digits</button>
 
       <p>
-        The code to render these examples isn't built into tfjs. But because you have full access to the DOM element for each surface,
-        you can draw whatever you would like into them. This allows easy integration of custom visualizations into the visor.
+        The code to render these examples isn't built into tfjs. But because you have full access to the DOM element
+        for each surface,
+        you can draw whatever you would like into them. This allows easy integration of custom visualizations into the
+        visor.
 
         <p>
           Here is the code for the "Show Example Digits" button above:
@@ -175,7 +186,8 @@
     <section>
       <h2>Training Our Model</h2>
       <p>
-        Our goal is to train a model to recognize similar digits. We have already written a tutorial on how to do so. So in this
+        Our goal is to train a model to recognize similar digits. We have already written a tutorial on how to do so.
+        So in this
         article we are going to focus on monitoring that training and also look at how well our model performs.
       </p>
 
@@ -206,7 +218,7 @@
           return model.fit(trainXs, trainYs, {
             batchSize: BATCH_SIZE,
             validationData: [testXs, testYs],
-            epochs: 10,
+            epochs: 2,
             shuffle: true,
             callbacks: fitCallbacks
           });
@@ -214,7 +226,8 @@
       </script>
 
       <p>
-        We can use the <code>show.fitCallbacks</code> method to get functions that will plot the loss after every batch and
+        We can use the <code>show.fitCallbacks</code> method to get functions that will plot the loss after every batch
+        and
         epoch.
       </p>
 
@@ -222,8 +235,10 @@
 
       <script class='show-script'>
         async function watchTraining1() {
-          const metrics = ['loss', 'acc', 'val_acc'];
-          const container = { name: 'model.fit metrics', tab: 'Training' };
+          const metrics = ['loss', 'val_loss', 'acc', 'val_acc'];
+          const container = {
+            name: 'show.fitCallbacks', tab: 'Training', styles: { height: '1000px' }
+          };
           const callbacks = tfvis.show.fitCallbacks(container, metrics);
           return train(model, data, callbacks);
         }
@@ -284,7 +299,7 @@
         async function showTrainingHistory() {
           const trainingHistory = await train(model, data);
           tfvis.show.history({ name: 'Training History', tab: 'Training' },
-            trainingHistory, ['loss', 'acc']);
+            trainingHistory, ['loss', 'val_loss', 'acc', 'val_acc']);
         }
 
         document.querySelector('#start-training-3')
@@ -295,7 +310,8 @@
     <section>
       <h2>Evaluating Our Model</h2>
       <p>
-        Now that our model is trained we should evalute its performance. For a classification task like this one we can use the `perClassAccuracy`
+        Now that our model is trained we should evalute its performance. For a classification task like this one we can
+        use the `perClassAccuracy`
         and `confusionMatrix` functions. These are demonstrated below.
       </p>
 

--- a/src/show/history.ts
+++ b/src/show/history.ts
@@ -44,21 +44,21 @@ export async function history(
   // multi-series charts.
   const plots: HistoryPlotData = {};
   for (const metric of metrics) {
-    if (metric.match('loss')) {
-      const values = getValues(history, metric, metrics.indexOf(metric));
-      initPlot(plots, 'loss');
-      plots['loss'].series.push(metric);
-      plots['loss'].values.push(values);
-    } else if (metric.match('acc')) {
-      const values = getValues(history, metric, metrics.indexOf(metric));
-      initPlot(plots, 'acc');
-      plots['acc'].series.push(metric);
-      plots['acc'].values.push(values);
-    } else {
+    if (!(/val_/.test(metric))) {
+      // Non validation metric
       const values = getValues(history, metric, metrics.indexOf(metric));
       initPlot(plots, metric);
       plots[metric].series.push(metric);
       plots[metric].values.push(values);
+    } else {
+      // Validation metrics are grouped with their equivalent non validation
+      // metrics. Note that the corresponding non validation metric may not
+      // actually be included but we still want to use it as a plot name.
+      const nonValidationMetric = metric.replace('val_', '');
+      initPlot(plots, nonValidationMetric);
+      const values = getValues(history, metric, metrics.indexOf(metric));
+      plots[nonValidationMetric].series.push(metric);
+      plots[nonValidationMetric].values.push(values);
     }
   }
 

--- a/src/show/history_test.ts
+++ b/src/show/history_test.ts
@@ -32,22 +32,20 @@ describe('fitCallbacks', () => {
 
   it('onEpochEnd callback can render logs', async () => {
     const container = {name: 'Test'};
-    const callbacks = fitCallbacks(container, ['loss', 'acc']);
+    const callbacks =
+        fitCallbacks(container, ['loss', 'val-loss', 'acc', 'val-acc']);
 
-    const l1 = {loss: 0.5};
-    const l2 = {loss: 0.2, acc: 0.6};
+    const l1 = {loss: 0.5, 'val-loss': 0.7};
+    const l2 = {loss: 0.2, acc: 0.6, 'val-loss': 0.5, 'val-acc': 0.3};
 
     await callbacks.onEpochEnd(0, l1);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
-    expect(document.querySelectorAll('div[data-name="loss—onEpochEnd"]').length)
-        .toBe(1);
+    expect(document.querySelectorAll('div[data-name="loss"]').length).toBe(1);
 
-    await callbacks.onEpochEnd(0, l2);
+    await callbacks.onEpochEnd(1, l2);
     expect(document.querySelectorAll('.vega-embed').length).toBe(2);
-    expect(document.querySelectorAll('div[data-name="loss—onEpochEnd"]').length)
-        .toBe(1);
-    expect(document.querySelectorAll('div[data-name="acc—onEpochEnd"]').length)
-        .toBe(1);
+    expect(document.querySelectorAll('div[data-name="loss"]').length).toBe(1);
+    expect(document.querySelectorAll('div[data-name="acc"]').length).toBe(1);
   });
 
   it('onBatchEnd callback can render logs', async () => {
@@ -59,15 +57,12 @@ describe('fitCallbacks', () => {
 
     await callbacks.onBatchEnd(0, l1);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
-    expect(document.querySelectorAll('div[data-name="loss—onBatchEnd"]').length)
-        .toBe(1);
+    expect(document.querySelectorAll('div[data-name="loss"]').length).toBe(1);
 
-    await callbacks.onBatchEnd(0, l2);
+    await callbacks.onBatchEnd(1, l2);
     expect(document.querySelectorAll('.vega-embed').length).toBe(2);
-    expect(document.querySelectorAll('div[data-name="loss—onBatchEnd"]').length)
-        .toBe(1);
-    expect(document.querySelectorAll('div[data-name="acc—onBatchEnd"]').length)
-        .toBe(1);
+    expect(document.querySelectorAll('div[data-name="loss"]').length).toBe(1);
+    expect(document.querySelectorAll('div[data-name="acc"]').length).toBe(1);
   });
 });
 
@@ -91,7 +86,7 @@ describe('history', () => {
     const metrics = ['loss', 'acc'];
     await history(container, logs, metrics);
 
-    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+    expect(document.querySelectorAll('.vega-embed').length).toBe(2);
   });
 
   it('renders a history object with multiple metrics', async () => {
@@ -105,7 +100,7 @@ describe('history', () => {
     const metrics = ['loss', 'acc'];
     await history(container, hist, metrics);
 
-    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+    expect(document.querySelectorAll('.vega-embed').length).toBe(2);
   });
 
   it('can render multiple history objects', async () => {

--- a/src/show/history_test.ts
+++ b/src/show/history_test.ts
@@ -33,10 +33,10 @@ describe('fitCallbacks', () => {
   it('onEpochEnd callback can render logs', async () => {
     const container = {name: 'Test'};
     const callbacks =
-        fitCallbacks(container, ['loss', 'val-loss', 'acc', 'val-acc']);
+        fitCallbacks(container, ['loss', 'val_loss', 'acc', 'val_acc']);
 
-    const l1 = {loss: 0.5, 'val-loss': 0.7};
-    const l2 = {loss: 0.2, acc: 0.6, 'val-loss': 0.5, 'val-acc': 0.3};
+    const l1 = {loss: 0.5, 'val_loss': 0.7};
+    const l2 = {loss: 0.2, acc: 0.6, 'val_loss': 0.5, 'val_acc': 0.3};
 
     await callbacks.onEpochEnd(0, l1);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -31,7 +31,17 @@ const DEFAULT_SUBSURFACE_OPTS = {
 export function subSurface(parent: Drawable, name: string, opts: Options = {}) {
   const container = getDrawArea(parent);
   const style = css({...tac('mv2')});
-  const finalOpts = Object.assign({}, DEFAULT_SUBSURFACE_OPTS, opts);
+  const titleStyle = css({
+    backgroundColor: 'white',
+    display: 'inline-block',
+    boxSizing: 'border-box',
+    borderBottom: '1px solid #357EDD',
+    lineHeight: '2em',
+    padding: '0 10px 0 10px',
+    marginBottom: '20px',
+    ...tac('fw6 tl')
+  });
+  const options = Object.assign({}, DEFAULT_SUBSURFACE_OPTS, opts);
 
   let sub: HTMLElement|null = container.querySelector(`div[data-name=${name}]`);
   if (!sub) {
@@ -39,7 +49,14 @@ export function subSurface(parent: Drawable, name: string, opts: Options = {}) {
     sub.setAttribute('class', `${style}`);
     sub.dataset.name = name;
 
-    if (finalOpts.prepend) {
+    if (options.title) {
+      const title = document.createElement('div');
+      title.setAttribute('class', `subsurface-title ${titleStyle}`);
+      title.innerText = options.title;
+      sub.appendChild(title);
+    }
+
+    if (options.prepend) {
       container.insertBefore(sub, container.firstChild);
     } else {
       container.appendChild(sub);
@@ -50,4 +67,5 @@ export function subSurface(parent: Drawable, name: string, opts: Options = {}) {
 
 interface Options {
   prepend?: boolean;
+  title?: string;
 }


### PR DESCRIPTION
This PR adds functionality to group accuracy metrics together and group loss metrics together. This closes https://github.com/tensorflow/tfjs/issues/812 but takes the approach of making the function to the appropriate thing rather than provide more specific configuration options.

the default output from show.fitCallbacks with the metrics `['loss', 'val_loss', 'acc', 'val_acc']` now shows the following.

<img width="536" alt="screen shot 2018-11-02 at 2 06 50 pm" src="https://user-images.githubusercontent.com/26408/48007365-729fad80-e0e5-11e8-98d1-2158ac243918.png">

Calling show.history _at the end of training_ (i.e. looking at epochs) with the same metrics shows. 

<img width="537" alt="screen shot 2018-11-02 at 2 06 56 pm" src="https://user-images.githubusercontent.com/26408/48007407-88ad6e00-e0e5-11e8-815a-937871ce0503.png">

In general these methods will always try to put together `acc` metrics and `loss` metrics respectively. I think we have a small enough set of things that we can put the logic for what should be put together inside the function and just handle whatever metrics the user passes in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/33)
<!-- Reviewable:end -->
