### PR TITLE
Add new optional parameters to show.history and show.fitCallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ rather than flexible but are generally combinations of `Renderers` (see below), 
 
 ### Model Training Visualization
 
-## show.history(container: Surface, history: HistoryLike,  metrics: string[]) => Promise<void>
+## show.history(container: Surface, history: HistoryLike,  metrics: string[], opts?: {}) => Promise<void>
 
 Renders a `tf.Model` training 'History' or callback 'Logs'. These are useful for plotting training metrics after or during
 training respectively.
@@ -213,9 +213,10 @@ training respectively.
 * @param container A `Surface` or `{name: string, tab?: string}` object specifying which surface to render to.
 * @param history A history-like object. Either a tfjs-layers `History` object or an array of tfjs-layers `Logs` objects. `Logs` are produced by the callbacks on [model.fit](https://js.tensorflow.org/api/latest/#tf.Model.fit) and a `History` object is returned from [model.fit](https://js.tensorflow.org/api/latest/#tf.Model.fit).
 * @param metrics An array of strings reprenting training metrics of a [tf.model](https://js.tensorflow.org/api/latest/#tf.Model.compile)
+* @param opts Optional parameters for the line charts. See the opts parameter for render.linechart for details. Notably for 'accuracy' related plots the domain of the yAxis will always by 0-1, i.e. zoomToFit and yAxisDomain options are ignored.
 
 
-## show.fitCallbacks(container: Surface  metrics: string[]) => {[key: string]: (iteration: number, log: Logs) => Promise<void>}
+## show.fitCallbacks(container: Surface  metrics: string[], opts?: {}) => {[key: string]: (iteration: number, log: Logs) => Promise<void>}
 
 Returns a collection of callbacks to pass to [model.fit](https://js.tensorflow.org/api/latest/#tf.Model.fit).
 Callbacks are returned for the following events, `onBatchEnd` & `onEpochEnd`.
@@ -228,7 +229,8 @@ on how to pass in callback functions to the training process.
 
 * @param container A `Surface` or `{name: string, tab?: string}` object specifying which surface to render to.
 * @param metrics An array of strings representing training [metrics](https://js.tensorflow.org/api/latest/#tf.Model.compile) of a [tf.model](https://js.tensorflow.org/api/latest/#class:Model)
-
+* @param opts Optional parameters for the line charts. See the opts parameter for render.linechart for details. Notably for 'accuracy' related plots the domain of the yAxis will always by 0-1, i.e. zoomToFit and yAxisDomain options are ignored.
+* @param opts.callbacks Array of strings with callback names. Valid options are 'onEpochEnd' and 'onBatchEnd'. Defaults to ['onEpochEnd', 'onBatchEnd'].
 
 ## show.perClassAccuracy(container: Drawable, classAccuracy: {accuracy: number[], count: number[]}, classLabels?: string[]) => Promise<void>
 

--- a/demos/mnist/index.html
+++ b/demos/mnist/index.html
@@ -234,7 +234,7 @@
       <button id='start-training-1' disabled>Start Training</button>
 
       <script class='show-script'>
-        async function watchTraining1() {
+        async function watchTraining() {
           const metrics = ['loss', 'val_loss', 'acc', 'val_acc'];
           const container = {
             name: 'show.fitCallbacks', tab: 'Training', styles: { height: '1000px' }
@@ -244,56 +244,14 @@
         }
 
         document.querySelector('#start-training-1')
-          .addEventListener('click', () => watchTraining1());
+          .addEventListener('click', () => watchTraining());
       </script>
 
       <p>
-        We can also use the <code>show.history</code> method to get more control over what we want plotted.
+        Another option is to wait for the training to complete and render the loss curve when it is done.
       </p>
 
       <button id='start-training-2' disabled>Start Training</button>
-
-      <script class='show-script'>
-        async function watchTraining2() {
-          // We need to keep accumulate the log objects from
-          // the tf.Model.fit callbacks
-          const batchLoss = [];
-          const epochAccHistory = [];
-
-          const callbacks = {
-            onBatchEnd: async (batch, h) => {
-              batchLoss.push(h);
-              tfvis.show.history(
-                { name: 'Loss on Batch End', tab: 'Training' },
-                batchLoss,
-                ['loss']
-              );
-
-              await tf.nextFrame();
-            },
-            onEpochEnd: async (epoch, h) => {
-              epochAccHistory.push(h);
-              tfvis.show.history(
-                { name: 'Accuracy on Epoch End', tab: 'Training' },
-                epochAccHistory,
-                ['acc', 'val_acc']
-              );
-
-            }
-          };
-
-          return train(model, data, callbacks);
-        }
-
-        document.querySelector('#start-training-2')
-          .addEventListener('click', () => watchTraining2());
-      </script>
-
-      <p>
-        A final option is to wait for the training to complete and render the loss curve when it is done.
-      </p>
-
-      <button id='start-training-3' disabled>Start Training</button>
 
       <script class='show-script'>
         async function showTrainingHistory() {
@@ -302,7 +260,7 @@
             trainingHistory, ['loss', 'val_loss', 'acc', 'val_acc']);
         }
 
-        document.querySelector('#start-training-3')
+        document.querySelector('#start-training-2')
           .addEventListener('click', () => showTrainingHistory());
       </script>
     </section>

--- a/src/show/history_test.ts
+++ b/src/show/history_test.ts
@@ -30,6 +30,16 @@ describe('fitCallbacks', () => {
     expect(typeof (callbacks.onBatchEnd)).toEqual('function');
   });
 
+  it('returns one callback', async () => {
+    const container = {name: 'Test'};
+    const callbacks = fitCallbacks(container, ['loss', 'acc'], {
+      callbacks: ['onBatchEnd'],
+    });
+
+    expect(callbacks.onEpochEnd).toEqual(undefined);
+    expect(typeof (callbacks.onBatchEnd)).toEqual('function');
+  });
+
   it('onEpochEnd callback can render logs', async () => {
     const container = {name: 'Test'};
     const callbacks =


### PR DESCRIPTION
This opts object allows setting properties on line charts, such as zoomToFit or fontSize, from show.* functions.

It also allows customizing which callbacks to generate functions for when using fitCallbacks (e.g. if a user only wants to plot metrics onEpochEnd.

Closes https://github.com/tensorflow/tfjs/issues/849 
Closes https://github.com/tensorflow/tfjs/issues/850 