### PR TITLE
Shade confusion matrix diagonal by default. Improve overall design.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ Renders a per class accuracy table for classification task evaluation
 
 Renders a confusion matrix for classification task evaluation
 
+Can optionally exclude the diagonal from being shaded if one wants the visual
+focus to be on the incorrect classifications. Note that if the classification
+is perfect (i.e. only the diagonal has values) then the diagonal will always
+be shaded.
+
 * @param container A `{name: string, tab?: string}` object specifying which
   surface to render to.
 * @param confusionMatrix A nested array of numbers with the confusion matrix

--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -397,7 +397,7 @@
         }
       </script>
 
-      <p>The diagonal can also be shaded.</p>
+      <p>The diagonal can also be excluded from shading.</p>
 
       <div id='confmatrix-cont2'></div>
 
@@ -410,10 +410,10 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({
-            name: 'Confusion Matrix with Diagonal', tab: 'Charts'
+            name: 'Confusion Matrix with Excluded Diagonal', tab: 'Charts'
           });
           tfvis.render.confusionMatrix(data, surface, {
-            shadeDiagonal: true
+            shadeDiagonal: false
           });
 
           // Render to page
@@ -421,7 +421,67 @@
           tfvis.render.confusionMatrix(data, container, {
             width: 500,
             height: 500,
-            shadeDiagonal: true,
+            shadeDiagonal: false,
+          });
+        }
+      </script>
+
+      <p>Perfect classification.</p>
+
+      <div id='confmatrix-cont3'></div>
+
+
+      <script class='show-script'>
+        {
+          const data = {
+            values: [[8, 0, 0], [0, 8, 0], [0, 0, 8]],
+            // We also generate 'labels' if none are passed.
+          }
+
+          // Render to visor
+          const surface = tfvis.visor().surface({
+            name: 'Confusion Matrix with perfect classification', tab: 'Charts'
+          });
+          tfvis.render.confusionMatrix(data, surface);
+
+          // Render to page
+          const container = document.getElementById('confmatrix-cont3');
+          tfvis.render.confusionMatrix(data, container, {
+            width: 500,
+            height: 500,
+          });
+
+
+        }
+      </script>
+
+      <p>In a perfect classification scenario where shadeDiagonal is false the chart
+        will override that option as all values lie on the diagonal.
+      </p>
+
+      <div id='confmatrix-cont4'></div>
+
+      <script class='show-script'>
+        {
+          const data = {
+            values: [[8, 0, 0], [0, 8, 0], [0, 0, 8]],
+            // We also generate 'labels' if none are passed.
+          }
+
+          // Render to visor
+          const surface = tfvis.visor().surface({
+            name: 'Confusion Matrix with perfect classification shadeDiagonal=false', tab: 'Charts'
+          });
+          tfvis.render.confusionMatrix(data, surface, {
+            shadeDiagonal: false,
+          });
+
+          // Render to page
+          const container = document.getElementById('confmatrix-cont4');
+          tfvis.render.confusionMatrix(data, container, {
+            width: 500,
+            height: 500,
+            shadeDiagonal: false,
           });
         }
       </script>


### PR DESCRIPTION
Closes https://github.com/tensorflow/tfjs/issues/974
Closes https://github.com/tensorflow/tfjs/issues/916

Changes the default of shadeDiagonal to true to better match initial user expectations.

<img width="527" alt="screen shot 2018-12-07 at 2 00 44 pm" src="https://user-images.githubusercontent.com/26408/49667415-f3293500-fa28-11e8-84de-1cbc8309d57e.png">
<img width="531" alt="screen shot 2018-12-07 at 2 00 39 pm" src="https://user-images.githubusercontent.com/26408/49667416-f3293500-fa28-11e8-8bb2-ceccd8539bb7.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/39)
<!-- Reviewable:end -->
