### PR TITLE
Add heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,39 @@ Renders a confusion matrix
 * @param opts.fontSize fontSize in pixels for text in the chart
 
 
+## render.heatmap(data: {}, container: Surface|HTMLElement, opts: {}): Promise<void>
+
+
+Renders a heatmap.
+
+* @param data Data consists of an object with a 'values' property
+  and a 'labels' property.
+  ```ts
+  {
+    // a matrix of numbers
+    values: number[][]|Tensor2d,
+    // Human readable labels for each class in the matrix. Optional
+    xLabels?: string[]
+    yLabels?: string[]
+  }
+  e.g.
+  {
+    values: [[80, 23], [56, 94]],
+    xLabels: ['dog', 'cat'],
+    yLabels: ['size', 'temperature'],
+  }
+  ```
+* @param container An `HTMLElement` or `Surface` in which to draw the chart
+* @param opts optional parameters
+* @param opts.colorMap which colormap to use. One of viridis|blues|greyscale. Defaults to viridis
+* @param opts.domain a two element array representing a custom output domain
+  for the color scale. Useful if you want to plot multiple heatmaps using
+  the same scale.
+* @param opts.width width of chart in px
+* @param opts.height height of chart in px
+* @param opts.fontSize fontSize in pixels for text in the chart
+
+
 ## Metrics
 
 The `metrics` namespace contains a few utility functions for computing quality metrics

--- a/README.md
+++ b/README.md
@@ -445,8 +445,8 @@ Renders a confusion matrix
   ```
 * @param container An `HTMLElement` or `Surface` in which to draw the chart
 * @param opts optional parameters
-* @param opts.shadeDiagonal boolean that controls whether or not to color cells
-* on the diagonal. Defaults to false
+* @param opts.shadeDiagonal boolean that controls whether or not to color cells on the diagonal. Defaults to false
+* @param opts.showTextOverlay boolean that controls whether or not to render the values of each cell as text. Defaults to true
 * @param opts.width width of chart in px
 * @param opts.height height of chart in px
 * @param opts.fontSize fontSize in pixels for text in the chart

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Renders a heatmap.
   ```ts
   {
     // a matrix of numbers
-    values: number[][]|Tensor2d,
+    values: number[][]|Tensor2D,
     // Human readable labels for each class in the matrix. Optional
     xLabels?: string[]
     yLabels?: string[]
@@ -474,15 +474,17 @@ Renders a heatmap.
     yLabels: ['size', 'temperature'],
   }
   ```
-* @param container An `HTMLElement` or `Surface` in which to draw the chart
-* @param opts optional parameters
-* @param opts.colorMap which colormap to use. One of viridis|blues|greyscale. Defaults to viridis
+* @param container An `HTMLElement` or `Surface` in which to draw the chart.
+* @param opts optional parameters.
+* @param opts.colorMap which colormap to use. One of viridis|blues|greyscale. Defaults to viridis.
 * @param opts.domain a two element array representing a custom output domain
   for the color scale. Useful if you want to plot multiple heatmaps using
   the same scale.
-* @param opts.width width of chart in px
-* @param opts.height height of chart in px
-* @param opts.fontSize fontSize in pixels for text in the chart
+* @param opts.xLabel label for x axis
+* @param opts.yLabel label for y axis
+* @param opts.width width of chart in px.
+* @param opts.height height of chart in px.
+* @param opts.fontSize fontSize in pixels for text in the chart.
 
 
 ## Metrics

--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -393,7 +393,7 @@
             const row = []
             for (let j = 0; j < cols; j++) {
               row.push(Math.round(Math.random() * 50));
-          }
+            }
             values.push(row);
           }
           const data = { values: values };
@@ -507,11 +507,17 @@
 
       <script class='show-script'>
         {
-          const data = {
-            values: [[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]],
-            xLabels: ['cheese', 'pig', 'font'],
-            yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+          const rows = 50;
+          const cols = 20;
+          const values = [];
+          for (let i = 0; i < rows; i++) {
+            const row = []
+            for (let j = 0; j < cols; j++) {
+              row.push(Math.random() * 100);
+            }
+            values.push(row);
           }
+          const data = { values: values };
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Heatmap', tab: 'Charts' });
@@ -520,6 +526,58 @@
           // Render to page
           const container = document.getElementById('heatmap-cont');
           tfvis.render.heatmap(data, container, { width: 500, height: 500 });
+        }
+      </script>
+
+      <p>
+        We can also pass in custom labels
+      </p>
+      <div id='heatmap-cont2'></div>
+
+      <script class='show-script'>
+        {
+          const data = {
+            values: [[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]],
+            xLabels: ['cheese', 'pig', 'font'],
+            yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+          }
+
+          // Render to visor
+          const surface = tfvis.visor().surface({ name: 'Heatmap w Custom Labels', tab: 'Charts' });
+          tfvis.render.heatmap(data, surface);
+
+          // Render to page
+          const container = document.getElementById('heatmap-cont2');
+          tfvis.render.heatmap(data, container, { width: 500, height: 500 });
+        }
+      </script>
+
+      <p>
+        Alternate color maps are also supported.
+      </p>
+      <div id='heatmap-cont3'></div>
+
+      <script class='show-script'>
+        {
+          const data = {
+            values: [[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]],
+            xLabels: ['cheese', 'pig', 'font'],
+            yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+          }
+
+          // Render to visor
+          const surface = tfvis.visor().surface({ name: 'Heatmap w Custom Colormap', tab: 'Charts' });
+          tfvis.render.heatmap(data, surface, {
+            colorMap: 'greyscale',
+          });
+
+          // Render to page
+          const container = document.getElementById('heatmap-cont3');
+          tfvis.render.heatmap(data, container, {
+            colorMap: 'greyscale',
+            width: 500,
+            height: 500
+          });
         }
       </script>
 

--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -491,6 +491,28 @@
 
       <hr>
 
+      <h3>render.heatmap(data, container, opts)</h3>
+
+      <div id='heatmap-cont'></div>
+
+      <script class='show-script'>
+        {
+          const data = {
+            values: [[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]],
+            xLabels: ['cheese', 'pig', 'font'],
+            yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+          }
+
+          // Render to visor
+          const surface = tfvis.visor().surface({ name: 'Heatmap', tab: 'Charts' });
+          tfvis.render.heatmap(data, surface);
+
+          // Render to page
+          const container = document.getElementById('heatmap-cont');
+          tfvis.render.heatmap(data, container, { width: 500, height: 500 });
+        }
+      </script>
+
     </section>
 
   </article>

--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -385,18 +385,28 @@
 
       <script class='show-script'>
         {
-          const data = {
-            values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
-            labels: ['cheese', 'pig', 'font'],
+
+          const rows = 50;
+          const cols = 50;
+          const values = [];
+          for (let i = 0; i < rows; i++) {
+            const row = []
+            for (let j = 0; j < cols; j++) {
+              row.push(Math.round(Math.random() * 50));
           }
+            values.push(row);
+          }
+          const data = { values: values };
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Confusion Matrix', tab: 'Charts' });
-          tfvis.render.confusionMatrix(data, surface);
+          tfvis.render.confusionMatrix(data, surface, {
+            showTextOverlay: false
+          });
 
           // Render to page
           const container = document.getElementById('confmatrix-cont');
-          tfvis.render.confusionMatrix(data, container, { width: 500, height: 500 });
+          tfvis.render.confusionMatrix(data, container, { width: 800, height: 800 });
         }
       </script>
 

--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -581,6 +581,33 @@
         }
       </script>
 
+
+      <p>
+        Tensor2D's are also supported
+      </p>
+      <div id='heatmap-cont4'></div>
+
+      <script class='show-script'>
+        {
+          const data = {
+            values: tf.tensor2d([[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]]),
+            xLabels: ['cheese', 'pig', 'font'],
+            yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+          }
+
+          // Render to visor
+          const surface = tfvis.visor().surface({ name: 'Heatmap', tab: 'Tensor Charts' });
+          tfvis.render.heatmap(data, surface);
+
+          // Render to page
+          const container = document.getElementById('heatmap-cont4');
+          tfvis.render.heatmap(data, container, {
+            width: 500,
+            height: 500
+          });
+        }
+      </script>
+
     </section>
 
   </article>

--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -396,7 +396,7 @@
             }
             values.push(row);
           }
-          const data = { values: values };
+          const data = { values };
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Confusion Matrix', tab: 'Charts' });
@@ -513,11 +513,11 @@
           for (let i = 0; i < rows; i++) {
             const row = []
             for (let j = 0; j < cols; j++) {
-              row.push(Math.random() * 100);
+              row.push(i * j)
             }
             values.push(row);
           }
-          const data = { values: values };
+          const data = { values };
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Heatmap', tab: 'Charts' });
@@ -581,7 +581,6 @@
         }
       </script>
 
-
       <p>
         Tensor2D's are also supported
       </p>
@@ -597,17 +596,21 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Heatmap', tab: 'Tensor Charts' });
-          tfvis.render.heatmap(data, surface);
+          tfvis.render.heatmap(data, surface, {
+            xLabel: 'Thing',
+            yLabel: 'Property',
+          });
 
           // Render to page
           const container = document.getElementById('heatmap-cont4');
           tfvis.render.heatmap(data, container, {
             width: 500,
-            height: 500
+            height: 500,
+            xLabel: 'Thing',
+            yLabel: 'Property',
           });
         }
       </script>
-
     </section>
 
   </article>

--- a/demos/api/index.js
+++ b/demos/api/index.js
@@ -1,2 +1,4 @@
+import * as tf from '@tensorflow/tfjs'
 import * as tfvis from '../../src/index.ts';
+window.tf = tf;
 window.tfvis = tfvis;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
 
 import {renderBarchart} from './render/barchart';
 import {renderConfusionMatrix} from './render/confusion_matrix';
+import {renderHeatmap} from './render/heatmap';
 import {renderHistogram} from './render/histogram';
 import {renderLinechart} from './render/linechart';
 import {renderScatterplot} from './render/scatterplot';
@@ -34,6 +35,7 @@ const render = {
   linechart: renderLinechart,
   scatterplot: renderScatterplot,
   confusionMatrix: renderConfusionMatrix,
+  heatmap: renderHeatmap,
 };
 
 const metrics = {

--- a/src/render/confusion_matrix.ts
+++ b/src/render/confusion_matrix.ts
@@ -47,13 +47,16 @@ import {getDrawArea} from './render_utils';
  * @param opts optional parameters
  * @param opts.shadeDiagonal boolean that controls whether or not to color cells
  * on the diagonal. Defaults to true.
+ * @param opts.showTextOverlay boolean that controls whether or not to render
+ * the values of each cell as text. Defaults to true.
  * @param opts.width width of chart in px
  * @param opts.height height of chart in px
  * @param opts.fontSize fontSize in pixels for text in the chart
  */
 export async function renderConfusionMatrix(
     data: ConfusionMatrixData, container: Drawable,
-    opts: VisOptions&{shadeDiagonal?: boolean} = {}): Promise<void> {
+    opts: VisOptions&
+    {shadeDiagonal?: boolean, showTextOverlay?: boolean} = {}): Promise<void> {
   const options = Object.assign({}, defaultOpts, opts);
   const drawArea = getDrawArea(container);
 
@@ -62,13 +65,20 @@ export async function renderConfusionMatrix(
   const values: MatrixEntry[] = [];
 
   const inputArray = data.values;
-  const labels = data.labels;
+  const labels = data.labels || [];
+  const generateLabels = labels.length === 0;
 
   let nonDiagonalIsAllZeroes = true;
   for (let i = 0; i < inputArray.length; i++) {
+    const label = generateLabels ? `Class ${i}` : labels[i];
+
+    if (generateLabels) {
+      labels.push(label);
+    }
+
     for (let j = 0; j < inputArray[i].length; j++) {
-      const label = labels ? labels[i] : `Class ${i}`;
-      const prediction = labels ? labels[j] : `Class ${j}`;
+      const prediction = generateLabels ? `Class ${j}` : labels[j];
+
       const count = inputArray[i][j];
       if (i === j && !options.shadeDiagonal) {
         values.push({
@@ -175,23 +185,26 @@ export async function renderConfusionMatrix(
         },
 
       },
-      {
-        // The text labels
-        'mark': {'type': 'text', 'baseline': 'middle'},
-        'encoding': {
-          'text': {
-            'condition': {
-              'test': 'datum["noFill"] == true',
-              'field': 'diagCount',
-              'type': 'nominal',
-            },
-            'field': 'count',
-            'type': 'nominal',
-          },
-        }
-      },
     ]
   };
+
+  if (options.showTextOverlay) {
+    spec.layer.push({
+      // The text labels
+      'mark': {'type': 'text', 'baseline': 'middle'},
+      'encoding': {
+        'text': {
+          'condition': {
+            'test': 'datum["noFill"] == true',
+            'field': 'diagCount',
+            'type': 'nominal',
+          },
+          'field': 'count',
+          'type': 'nominal',
+        },
+      }
+    });
+  }
 
   await embed(drawArea, spec, embedOpts);
   return Promise.resolve();
@@ -204,6 +217,7 @@ const defaultOpts = {
   yType: 'nominal',
   shadeDiagonal: true,
   fontSize: 12,
+  showTextOverlay: true,
 };
 
 interface MatrixEntry {

--- a/src/render/confusion_matrix.ts
+++ b/src/render/confusion_matrix.ts
@@ -46,9 +46,9 @@ import {getDrawArea} from './render_utils';
  * @param container An `HTMLElement` or `Surface` in which to draw the chart
  * @param opts optional parameters
  * @param opts.shadeDiagonal boolean that controls whether or not to color cells
- * on the diagonal. Defaults to true.
+ * on the diagonal. Defaults to true
  * @param opts.showTextOverlay boolean that controls whether or not to render
- * the values of each cell as text. Defaults to true.
+ * the values of each cell as text. Defaults to true
  * @param opts.width width of chart in px
  * @param opts.height height of chart in px
  * @param opts.fontSize fontSize in pixels for text in the chart

--- a/src/render/heatmap.ts
+++ b/src/render/heatmap.ts
@@ -16,7 +16,7 @@
  */
 
 import embed, {Mode, VisualizationSpec} from 'vega-embed';
-import {ExtendedLayerSpec} from 'vega-lite/src/spec';
+type ExtendedLayerSpec = import('vega-lite').spec.ExtendedLayerSpec;
 
 import {Drawable, HeatmapData, VisOptions,} from '../types';
 
@@ -68,8 +68,8 @@ export async function renderHeatmap(
 
   for (let i = 0; i < inputArray.length; i++) {
     for (let j = 0; j < inputArray[i].length; j++) {
-      const x = xLabels ? xLabels[i] : `${i}`;
-      const y = yLabels ? yLabels[j] : `${j}`;
+      const x = xLabels ? xLabels[i] : i;
+      const y = yLabels ? yLabels[j] : j;
       const count = inputArray[i][j];
       values.push({
         x,
@@ -180,8 +180,8 @@ const defaultOpts = {
 };
 
 interface MatrixEntry {
-  x: string;
-  y: string;
+  x: string|number;
+  y: string|number;
   count: number;
 }
 

--- a/src/render/heatmap.ts
+++ b/src/render/heatmap.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import embed, {Mode, VisualizationSpec} from 'vega-embed';
+import {ExtendedLayerSpec} from 'vega-lite/src/spec';
+
+import {Drawable, HeatmapData, VisOptions,} from '../types';
+
+import {getDrawArea} from './render_utils';
+
+/**
+ * Renders a heatmap.
+ *
+ * @param data Data consists of an object with a 'values' property
+ *  and a 'labels' property.
+ *  {
+ *    // a matrix of numbers
+ *    values: number[][],
+ *
+ *    // Human readable labels for each class in the matrix. Optional
+ *    xLabels?: string[]
+ *    yLabels?: string[]
+ *  }
+ *  e.g.
+ *  {
+ *    values: [[80, 23], [56, 94]],
+ *    xLabels: ['dog', 'cat'],
+ *    yLabels: ['size', 'temperature'],
+ *  }
+ * @param container An `HTMLElement` or `Surface` in which to draw the chart
+ * @param opts optional parameters
+ * @param opts.colorMap which colormap to use. One of viridis|blues|greyscale.
+ *     Defaults to viridis
+ * @param opts.domain a two element array representing a custom output domain
+ *     for the color scale. Useful if you want to plot multiple heatmaps using
+ *     the same scale.
+ * @param opts.width width of chart in px
+ * @param opts.height height of chart in px
+ * @param opts.fontSize fontSize in pixels for text in the chart
+ */
+export async function renderHeatmap(
+    data: HeatmapData, container: Drawable,
+    opts: VisOptions&
+    {colorMap?: ColorMap, domain?: number[]} = {}): Promise<void> {
+  const options = Object.assign({}, defaultOpts, opts);
+  const drawArea = getDrawArea(container);
+
+  // Format data for vega spec; an array of objects, one for for each cell
+  // in the matrix.
+  const values: MatrixEntry[] = [];
+
+  const inputArray = data.values;
+  const {xLabels, yLabels} = data;
+
+  for (let i = 0; i < inputArray.length; i++) {
+    for (let j = 0; j < inputArray[i].length; j++) {
+      const x = xLabels ? xLabels[i] : `${i}`;
+      const y = yLabels ? yLabels[j] : `${j}`;
+      const count = inputArray[i][j];
+      values.push({
+        x,
+        y,
+        count,
+      });
+    }
+  }
+
+  const embedOpts = {
+    actions: false,
+    mode: 'vega-lite' as Mode,
+    defaultStyle: false,
+  };
+
+  const spec: VisualizationSpec = {
+    'width': options.width || drawArea.clientWidth,
+    'height': options.height || drawArea.clientHeight,
+    'padding': 5,
+    'autosize': {
+      'type': 'fit',
+      'contains': 'padding',
+      'resize': true,
+    },
+    'config': {
+      'axis': {
+        'labelFontSize': options.fontSize,
+        'titleFontSize': options.fontSize,
+      },
+      'text': {'fontSize': options.fontSize},
+      'legend': {
+        'labelFontSize': options.fontSize,
+        'titleFontSize': options.fontSize,
+      },
+      'scale': {'bandPaddingInner': 0, 'bandPaddingOuter': 0},
+    },
+    'data': {'values': values},
+    'encoding': {
+      'x': {
+        'field': 'x',
+        'type': 'ordinal',
+        // Maintain sort order of the axis if labels is passed in
+        'scale': {'domain': xLabels},
+        'title': options.xLabel,
+      },
+      'y': {
+        'field': 'y',
+        'type': 'ordinal',
+        // Maintain sort order of the axis if labels is passed in
+        'scale': {'domain': yLabels},
+        'title': options.yLabel,
+      },
+    },
+    'layer': [{
+      'mark': {'type': 'rect'},
+      'encoding': {
+        'fill': {
+          'field': 'count',
+          'type': 'quantitative',
+        },
+      },
+    }]
+  };
+
+  let colorRange: string[]|string;
+  switch (options.colorMap) {
+    case 'blues':
+      colorRange = ['#f7fbff', '#4292c6'];
+      break;
+    case 'greyscale':
+      colorRange = ['#000000', '#ffffff'];
+      break;
+    case 'viridis':
+    default:
+      colorRange = 'viridis';
+      break;
+  }
+  if (colorRange !== 'viridis') {
+    const fill = (spec.layer[0] as ExtendedLayerSpec).encoding!.fill!;
+    // @ts-ignore
+    fill.scale = {'range': colorRange};
+  }
+
+  if (options.domain) {
+    const fill = (spec.layer[0] as ExtendedLayerSpec).encoding!.fill!;
+    // @ts-ignore
+    if (fill.scale != null) {
+      // @ts-ignore
+      fill.scale = Object.assign({}, fill.scale, {'domain': options.domain});
+    } else {
+      // @ts-ignore
+      fill.scale = {'domain': options.domain};
+    }
+  }
+
+  await embed(drawArea, spec, embedOpts);
+  return Promise.resolve();
+}
+
+const defaultOpts = {
+  xLabel: null,
+  yLabel: null,
+  xType: 'nominal',
+  yType: 'nominal',
+  colorMap: 'viridis',
+  fontSize: 12,
+  domain: null,
+};
+
+interface MatrixEntry {
+  x: string;
+  y: string;
+  count: number;
+}
+
+type ColorMap = 'greyscale'|'viridis'|'blues';

--- a/src/render/heatmap_test.ts
+++ b/src/render/heatmap_test.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {renderHeatmap} from './heatmap';
+
+describe('renderHeatmap', () => {
+  let pixelRatio: number;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="container"></div>';
+    pixelRatio = window.devicePixelRatio;
+  });
+
+  it('renders a chart', async () => {
+    const data = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await renderHeatmap(data, container);
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+  });
+
+  it('renders a chart with custom colormap', async () => {
+    const data = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await renderHeatmap(data, container, {colorMap: 'greyscale'});
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+  });
+
+  it('renders a chart with custom domain', async () => {
+    const data = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await renderHeatmap(data, container, {domain: [0, 30]});
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+  });
+
+  it('renders a chart with custom labels', async () => {
+    const data = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
+      xLabels: ['cheese', 'pig', 'font'],
+      yLabels: ['speed', 'dexterity', 'roundness'],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await renderHeatmap(data, container);
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+  });
+
+  it('updates the chart', async () => {
+    let data = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+
+    await renderHeatmap(data, container);
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+
+    data = {
+      values: [[43, 2, 8], [1, 7, 2], [3, 3, 20]],
+    };
+
+    await renderHeatmap(data, container);
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+  });
+
+  it('sets width of chart', async () => {
+    const data = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await renderHeatmap(data, container, {width: 400});
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+    expect(document.querySelectorAll('canvas').length).toBe(1);
+    expect(document.querySelector('canvas')!.width).toBe(400 * pixelRatio);
+  });
+
+  it('sets height of chart', async () => {
+    const data = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await renderHeatmap(data, container, {height: 200});
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+    expect(document.querySelectorAll('canvas').length).toBe(1);
+    expect(document.querySelector('canvas')!.height).toBe(200 * pixelRatio);
+  });
+});

--- a/src/render/heatmap_test.ts
+++ b/src/render/heatmap_test.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import * as tf from '@tensorflow/tfjs';
+
 import {renderHeatmap} from './heatmap';
 
 describe('renderHeatmap', () => {
@@ -34,6 +36,40 @@ describe('renderHeatmap', () => {
     await renderHeatmap(data, container);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+  });
+
+  it('renders a chart with a tensor', async () => {
+    const values = tf.tensor2d([[4, 2, 8], [1, 7, 2], [3, 3, 20]]);
+    const data = {
+      values,
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await renderHeatmap(data, container);
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+
+    values.dispose();
+  });
+
+  it('throws an exception with a non 2d tensor', async () => {
+    const values = tf.tensor1d([4, 2, 8, 1, 7, 2, 3, 3, 20]);
+    const data = {
+      values,
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+
+    let threw = false;
+    try {
+      // @ts-ignore — passing in the wrong datatype
+      await renderHeatmap(data, container);
+    } catch (e) {
+      threw = true;
+    } finally {
+      values.dispose();
+    }
+    expect(threw).toBe(true);
   });
 
   it('renders a chart with custom colormap', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,15 +202,15 @@ export interface HistogramStats {
   numInfs?: number;
 }
 
+/**
+ * Type alias for typed arrays
+ */
 export type TypedArray = Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|
     Uint32Array|Uint8ClampedArray|Float32Array|Float64Array;
 
-export interface HeatmapData {
-  values: number[][]|Tensor2D;
-  xLabels?: string[];
-  yLabels?: string[];
-}
-
+/**
+ * Data format for confusion matrix
+ */
 export interface ConfusionMatrixData {
   values: number[][];
   labels?: string[];
@@ -222,3 +222,27 @@ export interface ConfusionMatrixData {
 export type Point2D = {
   x: number; y: number;
 };
+
+/**
+ * Data format for confusion matrix
+ */
+export interface HeatmapData {
+  values: number[][]|Tensor2D;
+  xLabels?: string[];
+  yLabels?: string[];
+}
+
+/**
+ * Color map names.
+ *
+ * Currently supported by heatmap
+ */
+export type NamedColorMap = 'greyscale'|'viridis'|'blues';
+
+/**
+ * Visualization options for Heatmap
+ */
+export interface HeatmapOptions extends VisOptions {
+  colorMap?: NamedColorMap;
+  domain?: number[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,12 @@ export interface HistogramStats {
 export type TypedArray = Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|
     Uint32Array|Uint8ClampedArray|Float32Array|Float64Array;
 
+export interface HeatmapData {
+  values: number[][];
+  xLabels?: string[];
+  yLabels?: string[];
+}
+
 export interface ConfusionMatrixData {
   values: number[][];
   labels?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import {Tensor2D} from '@tensorflow/tfjs';
+
 /*
  * @license
  * Copyright 2018 Google LLC. All Rights Reserved.
@@ -204,7 +206,7 @@ export type TypedArray = Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|
     Uint32Array|Uint8ClampedArray|Float32Array|Float64Array;
 
 export interface HeatmapData {
-  values: number[][];
+  values: number[][]|Tensor2D;
   xLabels?: string[];
   yLabels?: string[];
 }


### PR DESCRIPTION
adds a render.heatmap function.

(Note that this is separate from upcoming render.image* related functions, which would be more geared towards image like things and support higher-d tensors representing color channels.).

<img width="528" alt="screen shot 2018-12-20 at 3 25 35 pm" src="https://user-images.githubusercontent.com/26408/50309288-4e691780-046c-11e9-99b6-741c41ed9de9.png">

This is also the first render method that takes a tensor, though I intended render.image* to also do so. Overall this a few other things point towards changing the design a bit to have tensor support in render functions.

A bug in confusionMatrix was also fixed with regard to row/column ordering when no labels were passed in.

closes https://github.com/tensorflow/tfjs/issues/1000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/43)
<!-- Reviewable:end -->
