### PR TITLE
BREAKING: Rename xLabels/yLabels/labels to xTickLabels/yTickLabels/tickLabels

### DIFF
--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -605,8 +605,8 @@
         {
           const data = {
             values: [[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]],
-            xLabels: ['cheese', 'pig', 'font'],
-            yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+            xTickLabels: ['cheese', 'pig', 'font'],
+            yTickLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
           }
 
           // Render to visor
@@ -634,8 +634,8 @@
         {
           const data = {
             values: tf.tensor2d([[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]]),
-            xLabels: ['cheese', 'pig', 'font'],
-            yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+            xTickLabels: ['cheese', 'pig', 'font'],
+            yTickLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
           }
 
           // Render to visor

--- a/src/render/confusion_matrix.ts
+++ b/src/render/confusion_matrix.ts
@@ -71,12 +71,12 @@ import {getDrawArea} from './render_utils';
  *    values: number[][],
  *
  *    // Human readable labels for each class in the matrix. Optional
- *    labels?: string[]
+ *    tickLabels?: string[]
  *  }
  *  e.g.
  *  {
  *    values: [[80, 23], [56, 94]],
- *    labels: ['dog', 'cat'],
+ *    tickLabels: ['dog', 'cat'],
  *  }
  * @param container An `HTMLElement` or `Surface` in which to draw the chart
  * @param opts optional parameters
@@ -102,19 +102,19 @@ export async function renderConfusionMatrix(
   const values: MatrixEntry[] = [];
 
   const inputArray = data.values;
-  const labels = data.labels || [];
-  const generateLabels = labels.length === 0;
+  const tickLabels = data.tickLabels || [];
+  const generateLabels = tickLabels.length === 0;
 
   let nonDiagonalIsAllZeroes = true;
   for (let i = 0; i < inputArray.length; i++) {
-    const label = generateLabels ? `Class ${i}` : labels[i];
+    const label = generateLabels ? `Class ${i}` : tickLabels[i];
 
     if (generateLabels) {
-      labels.push(label);
+      tickLabels.push(label);
     }
 
     for (let j = 0; j < inputArray[i].length; j++) {
-      const prediction = generateLabels ? `Class ${j}` : labels[j];
+      const prediction = generateLabels ? `Class ${j}` : tickLabels[j];
 
       const count = inputArray[i][j];
       if (i === j && !options.shadeDiagonal) {
@@ -185,13 +185,13 @@ export async function renderConfusionMatrix(
         'field': 'prediction',
         'type': 'ordinal',
         // Maintain sort order of the axis if labels is passed in
-        'scale': {'domain': labels},
+        'scale': {'domain': tickLabels},
       },
       'y': {
         'field': 'label',
         'type': 'ordinal',
         // Maintain sort order of the axis if labels is passed in
-        'scale': {'domain': labels},
+        'scale': {'domain': tickLabels},
       },
     },
     'layer': [

--- a/src/render/confusion_matrix_test.ts
+++ b/src/render/confusion_matrix_test.ts
@@ -15,6 +15,8 @@
  * =============================================================================
  */
 
+import {ConfusionMatrixData} from '../types';
+
 import {renderConfusionMatrix} from './confusion_matrix';
 
 describe('renderConfusionMatrix', () => {
@@ -26,9 +28,9 @@ describe('renderConfusionMatrix', () => {
   });
 
   it('renders a chart', async () => {
-    const data = {
+    const data: ConfusionMatrixData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
-      labels: ['cheese', 'pig', 'font'],
+      tickLabels: ['cheese', 'pig', 'font'],
     };
 
     const container = document.getElementById('container') as HTMLElement;
@@ -38,9 +40,9 @@ describe('renderConfusionMatrix', () => {
   });
 
   it('renders a chart with shaded diagonal', async () => {
-    const data = {
+    const data: ConfusionMatrixData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
-      labels: ['cheese', 'pig', 'font'],
+      tickLabels: ['cheese', 'pig', 'font'],
     };
 
     const container = document.getElementById('container') as HTMLElement;
@@ -50,7 +52,7 @@ describe('renderConfusionMatrix', () => {
   });
 
   it('renders the chart with generated labels', async () => {
-    const data = {
+    const data: ConfusionMatrixData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 
@@ -61,9 +63,9 @@ describe('renderConfusionMatrix', () => {
   });
 
   it('updates the chart', async () => {
-    let data = {
+    let data: ConfusionMatrixData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
-      labels: ['cheese', 'pig', 'font'],
+      tickLabels: ['cheese', 'pig', 'font'],
     };
 
     const container = document.getElementById('container') as HTMLElement;
@@ -73,7 +75,7 @@ describe('renderConfusionMatrix', () => {
 
     data = {
       values: [[43, 2, 8], [1, 7, 2], [3, 3, 20]],
-      labels: ['cheese', 'pig', 'font'],
+      tickLabels: ['cheese', 'pig', 'font'],
     };
 
     await renderConfusionMatrix(data, container);
@@ -81,9 +83,9 @@ describe('renderConfusionMatrix', () => {
   });
 
   it('sets width of chart', async () => {
-    const data = {
+    const data: ConfusionMatrixData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
-      labels: ['cheese', 'pig', 'font'],
+      tickLabels: ['cheese', 'pig', 'font'],
     };
 
     const container = document.getElementById('container') as HTMLElement;
@@ -95,9 +97,9 @@ describe('renderConfusionMatrix', () => {
   });
 
   it('sets height of chart', async () => {
-    const data = {
+    const data: ConfusionMatrixData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
-      labels: ['cheese', 'pig', 'font'],
+      tickLabels: ['cheese', 'pig', 'font'],
     };
 
     const container = document.getElementById('container') as HTMLElement;

--- a/src/render/heatmap.ts
+++ b/src/render/heatmap.ts
@@ -47,8 +47,8 @@ import {getDrawArea} from './render_utils';
  * ```js
  * const data = {
  *   values: [[4, 2, 8, 20], [1, 7, 2, 10], [3, 3, 20, 13]],
- *   xLabels: ['cheese', 'pig', 'font'],
- *   yLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
+ *   xTickLabels: ['cheese', 'pig', 'font'],
+ *   yTickLabels: ['speed', 'smoothness', 'dexterity', 'mana'],
  * }
  *
  * // Render to visor
@@ -63,14 +63,14 @@ import {getDrawArea} from './render_utils';
  *    values: number[][]|Tensor2D,
  *
  *    // Human readable labels for each class in the matrix. Optional
- *    xLabels?: string[]
- *    yLabels?: string[]
+ *    xTickLabels?: string[]
+ *    yTickLabels?: string[]
  *  }
  *  e.g.
  *  {
  *    values: [[80, 23, 50], [56, 94, 39]],
- *    xLabels: ['dog', 'cat'],
- *    yLabels: ['size', 'temperature', 'agility'],
+ *    xTickLabels: ['dog', 'cat'],
+ *    yTickLabels: ['size', 'temperature', 'agility'],
  *  }
  * @param container An `HTMLElement` or `Surface` in which to draw the chart
  * @param opts optional parameters
@@ -96,7 +96,7 @@ export async function renderHeatmap(
   // Format data for vega spec; an array of objects, one for for each cell
   // in the matrix.
   const values: MatrixEntry[] = [];
-  const {xLabels, yLabels} = data;
+  const {xTickLabels, yTickLabels} = data;
 
   // These two branches are very similar but we want to do the test once
   // rather than on every element access
@@ -106,17 +106,19 @@ export async function renderHeatmap(
         'Input to renderHeatmap must be a 2d array or Tensor2d');
 
     const shape = data.values.shape;
-    if (xLabels) {
+    if (xTickLabels) {
       assert(
-          shape[0] === xLabels.length,
-          `Length of xLabels (${xLabels.length}) must match number of rows
+          shape[0] === xTickLabels.length,
+          `Length of xTickLabels (${
+              xTickLabels.length}) must match number of rows
           (${shape[0]})`);
     }
 
-    if (yLabels) {
+    if (yTickLabels) {
       assert(
-          shape[1] === yLabels.length,
-          `Length of xLabels (${yLabels.length}) must match number of columns
+          shape[1] === yTickLabels.length,
+          `Length of yTickLabels (${
+              yTickLabels.length}) must match number of columns
           (${shape[1]})`);
     }
 
@@ -127,9 +129,9 @@ export async function renderHeatmap(
     const [numRows, numCols] = shape;
 
     for (let row = 0; row < numRows; row++) {
-      const x = xLabels ? xLabels[row] : row;
+      const x = xTickLabels ? xTickLabels[row] : row;
       for (let col = 0; col < numCols; col++) {
-        const y = yLabels ? yLabels[col] : col;
+        const y = yTickLabels ? yTickLabels[col] : col;
 
         const index = (row * numCols) + col;
         const value = inputArray[index];
@@ -138,24 +140,24 @@ export async function renderHeatmap(
       }
     }
   } else {
-    if (xLabels) {
+    if (xTickLabels) {
       assert(
-          data.values.length === xLabels.length,
+          data.values.length === xTickLabels.length,
           `Number of rows (${data.values.length}) must match
-          number of xLabels (${xLabels.length})`);
+          number of xTickLabels (${xTickLabels.length})`);
     }
 
     const inputArray = data.values as number[][];
     for (let row = 0; row < inputArray.length; row++) {
-      const x = xLabels ? xLabels[row] : row;
-      if (yLabels) {
+      const x = xTickLabels ? xTickLabels[row] : row;
+      if (yTickLabels) {
         assert(
-            data.values[row].length === yLabels.length,
+            data.values[row].length === yTickLabels.length,
             `Number of columns in row ${row} (${data.values[row].length})
-            must match length of yLabels (${yLabels.length})`);
+            must match length of yTickLabels (${yTickLabels.length})`);
       }
       for (let col = 0; col < inputArray[row].length; col++) {
-        const y = yLabels ? yLabels[col] : col;
+        const y = yTickLabels ? yTickLabels[col] : col;
         const value = inputArray[row][col];
         values.push({x, y, value});
       }
@@ -196,14 +198,14 @@ export async function renderHeatmap(
         'field': 'x',
         'type': options.xType,
         // Maintain sort order of the axis if labels is passed in
-        'scale': {'domain': xLabels},
+        'scale': {'domain': xTickLabels},
         'title': options.xLabel,
       },
       'y': {
         'field': 'y',
         'type': options.yType,
         // Maintain sort order of the axis if labels is passed in
-        'scale': {'domain': yLabels},
+        'scale': {'domain': yTickLabels},
         'title': options.yLabel,
       },
       'fill': {

--- a/src/render/heatmap_test.ts
+++ b/src/render/heatmap_test.ts
@@ -17,6 +17,8 @@
 
 import * as tf from '@tensorflow/tfjs';
 
+import {HeatmapData} from '../types';
+
 import {renderHeatmap} from './heatmap';
 
 describe('renderHeatmap', () => {
@@ -28,7 +30,7 @@ describe('renderHeatmap', () => {
   });
 
   it('renders a chart', async () => {
-    const data = {
+    const data: HeatmapData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 
@@ -40,7 +42,7 @@ describe('renderHeatmap', () => {
 
   it('renders a chart with a tensor', async () => {
     const values = tf.tensor2d([[4, 2, 8], [1, 7, 2], [3, 3, 20]]);
-    const data = {
+    const data: HeatmapData = {
       values,
     };
 
@@ -73,7 +75,7 @@ describe('renderHeatmap', () => {
   });
 
   it('renders a chart with custom colormap', async () => {
-    const data = {
+    const data: HeatmapData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 
@@ -84,7 +86,7 @@ describe('renderHeatmap', () => {
   });
 
   it('renders a chart with custom domain', async () => {
-    const data = {
+    const data: HeatmapData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 
@@ -95,10 +97,10 @@ describe('renderHeatmap', () => {
   });
 
   it('renders a chart with custom labels', async () => {
-    const data = {
+    const data: HeatmapData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
-      xLabels: ['cheese', 'pig', 'font'],
-      yLabels: ['speed', 'dexterity', 'roundness'],
+      xTickLabels: ['cheese', 'pig', 'font'],
+      yTickLabels: ['speed', 'dexterity', 'roundness'],
     };
 
     const container = document.getElementById('container') as HTMLElement;
@@ -108,7 +110,7 @@ describe('renderHeatmap', () => {
   });
 
   it('updates the chart', async () => {
-    let data = {
+    let data: HeatmapData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 
@@ -126,7 +128,7 @@ describe('renderHeatmap', () => {
   });
 
   it('sets width of chart', async () => {
-    const data = {
+    const data: HeatmapData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 
@@ -139,7 +141,7 @@ describe('renderHeatmap', () => {
   });
 
   it('sets height of chart', async () => {
-    const data = {
+    const data: HeatmapData = {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 

--- a/src/show/quality.ts
+++ b/src/show/quality.ts
@@ -98,7 +98,7 @@ export async function showConfusionMatrix(
 
   const confusionMatrixData: ConfusionMatrixData = {
     values: confusionMatrix,
-    labels: classLabels,
+    tickLabels: classLabels,
   };
 
   return renderConfusionMatrix(confusionMatrixData, drawArea, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,8 +167,8 @@ export type Point2D = {
  */
 export interface HeatmapData {
   values: number[][]|Tensor2D;
-  xLabels?: string[];
-  yLabels?: string[];
+  xTickLabels?: string[];
+  yTickLabels?: string[];
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,7 @@ export type TypedArray = Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|
  */
 export interface ConfusionMatrixData {
   values: number[][];
-  labels?: string[];
+  tickLabels?: string[];
 }
 
 /**


### PR DESCRIPTION
Rename xLabels/yLabels/labels to xTickLabels/yTickLabels/tickLabels In heatmap and confusion matrix. Closes https://github.com/tensorflow/tfjs/issues/1114 and tries to distinguish more clearly between the label for the axis as a whole (xLabel) and the labels for ticks/rows/columns.

BREAKING

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/54)
<!-- Reviewable:end -->
