### PR TITLE
BREAKING Render param order

### DIFF
--- a/demos/api/index.html
+++ b/demos/api/index.html
@@ -93,11 +93,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Barchart', tab: 'Charts' });
-          tfvis.render.barchart(data, surface, {});
+          tfvis.render.barchart(surface, data, {});
 
           // Render to page
           const container = document.getElementById('barchart-cont');
-          tfvis.render.barchart(data, container, {
+          tfvis.render.barchart(container, data, {
             xLabel: 'my x axis',
             yLabel: 'values',
             width: 500,
@@ -135,7 +135,7 @@
           for (let i = 0; i < numRenders; i++) {
             const data = genData(numVals);
             const container = document.getElementById('barchart-multi');
-            await tfvis.render.barchart(data, container, {
+            await tfvis.render.barchart(container, data, {
               xLabel: 'my x axis',
               yLabel: 'values',
               width: 800,
@@ -175,11 +175,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Table', tab: 'Charts' });
-          tfvis.render.table({ headers, values }, surface);
+          tfvis.render.table(surface, { headers, values });
 
           // Render to page
           const container = document.getElementById('table-cont');
-          tfvis.render.table({ headers, values }, container, {
+          tfvis.render.table(container, { headers, values }, {
             fontSize: 14
           });
         }
@@ -202,11 +202,11 @@
           data.push(0);
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Histogram', tab: 'Charts' });
-          tfvis.render.histogram(data, surface);
+          tfvis.render.histogram(surface, data);
 
           // Render to page
           const container = document.getElementById('histogram-cont');
-          tfvis.render.histogram(data, container);
+          tfvis.render.histogram(container, data);
         }
       </script>
 
@@ -231,12 +231,12 @@
           for (let i = 0; i < numRenders; i++) {
             const data = genData(numVals);
             const container = document.getElementById('histogram-multi');
-            await tfvis.render.histogram(data, container, {
+            await tfvis.render.histogram(container, data, {
               stats: false,
             });
 
             const surface = { name: 'Histogram', tab: 'Re-renders' };
-            await tfvis.render.histogram(data, surface, {
+            await tfvis.render.histogram(surface, data, {
               stats: false,
             });
             await sleep(20);
@@ -270,11 +270,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Linechart', tab: 'Charts' });
-          tfvis.render.linechart(data, surface);
+          tfvis.render.linechart(surface, data);
 
           // Render to page
           const container = document.getElementById('linechart-cont');
-          tfvis.render.linechart(data, container);
+          tfvis.render.linechart(container, data);
         }
       </script>
 
@@ -291,11 +291,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Zoomed Line Chart', tab: 'Charts' });
-          tfvis.render.linechart(data, surface, { zoomToFit: true });
+          tfvis.render.linechart(surface, data, { zoomToFit: true });
 
           // Render to page
           const container = document.getElementById('zoomed-linechart-cont');
-          tfvis.render.linechart(data, container, { zoomToFit: true });
+          tfvis.render.linechart(container, data, { zoomToFit: true });
         }
       </script>
 
@@ -316,11 +316,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'truncated Line Chart', tab: 'Charts' });
-          tfvis.render.linechart(data, surface, { yAxisDomain: [80, 120] });
+          tfvis.render.linechart(surface, data, { yAxisDomain: [80, 120] });
 
           // Render to page
           const container = document.getElementById('truncated-linechart-cont');
-          tfvis.render.linechart(data, container, { yAxisDomain: [80, 120] });
+          tfvis.render.linechart(container, data, { yAxisDomain: [80, 120] });
         }
       </script>
 
@@ -346,11 +346,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Scatterplot', tab: 'Charts' });
-          tfvis.render.scatterplot(data, surface);
+          tfvis.render.scatterplot(surface, data);
 
           // Render to page
           const container = document.getElementById('scatterplot-cont');
-          tfvis.render.scatterplot(data, container, { width: 500, height: 500 });
+          tfvis.render.scatterplot(container, data, { width: 500, height: 500 });
         }
       </script>
 
@@ -374,11 +374,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Zoomed Scatterplot', tab: 'Charts' });
-          tfvis.render.scatterplot(data, surface, { zoomToFit: true });
+          tfvis.render.scatterplot(surface, data, { zoomToFit: true });
 
           // Render to page
           const container = document.getElementById('zoomed-scatterplot-cont');
-          tfvis.render.scatterplot(data, container, {
+          tfvis.render.scatterplot(container, data, {
             width: 500,
             height: 500,
             zoomToFit: true,
@@ -405,14 +405,14 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Custom Domain Scatterplot', tab: 'Charts' });
-          tfvis.render.scatterplot(data, surface, {
+          tfvis.render.scatterplot(surface, data, {
             xAxisDomain: [-20, 200],
             yAxisDomain: [-50, 125]
           });
 
           // Render to page
           const container = document.getElementById('customdomain-scatterplot-cont');
-          tfvis.render.scatterplot(data, container, {
+          tfvis.render.scatterplot(container, data, {
             width: 500,
             height: 500,
             xAxisDomain: [-20, 200],
@@ -423,7 +423,7 @@
 
       <hr>
 
-      <h3>render.confusionMatrix(data, container, opts)</h3>
+      <h3>render.confusionMatrix</h3>
 
       <div id='confmatrix-cont'></div>
 
@@ -444,13 +444,13 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Confusion Matrix', tab: 'Charts' });
-          tfvis.render.confusionMatrix(data, surface, {
+          tfvis.render.confusionMatrix(surface, data, {
             showTextOverlay: false
           });
 
           // Render to page
           const container = document.getElementById('confmatrix-cont');
-          tfvis.render.confusionMatrix(data, container, { width: 800, height: 800 });
+          tfvis.render.confusionMatrix(container, data, { width: 800, height: 800 });
         }
       </script>
 
@@ -469,13 +469,13 @@
           const surface = tfvis.visor().surface({
             name: 'Confusion Matrix with Excluded Diagonal', tab: 'Charts'
           });
-          tfvis.render.confusionMatrix(data, surface, {
+          tfvis.render.confusionMatrix(surface, data, {
             shadeDiagonal: false
           });
 
           // Render to page
           const container = document.getElementById('confmatrix-cont2');
-          tfvis.render.confusionMatrix(data, container, {
+          tfvis.render.confusionMatrix(container, data, {
             width: 500,
             height: 500,
             shadeDiagonal: false,
@@ -499,11 +499,11 @@
           const surface = tfvis.visor().surface({
             name: 'Confusion Matrix with perfect classification', tab: 'Charts'
           });
-          tfvis.render.confusionMatrix(data, surface);
+          tfvis.render.confusionMatrix(surface, data);
 
           // Render to page
           const container = document.getElementById('confmatrix-cont3');
-          tfvis.render.confusionMatrix(data, container, {
+          tfvis.render.confusionMatrix(container, data, {
             width: 500,
             height: 500,
           });
@@ -529,13 +529,13 @@
           const surface = tfvis.visor().surface({
             name: 'Confusion Matrix with perfect classification shadeDiagonal=false', tab: 'Charts'
           });
-          tfvis.render.confusionMatrix(data, surface, {
+          tfvis.render.confusionMatrix(surface, data, {
             shadeDiagonal: false,
           });
 
           // Render to page
           const container = document.getElementById('confmatrix-cont4');
-          tfvis.render.confusionMatrix(data, container, {
+          tfvis.render.confusionMatrix(container, data, {
             width: 500,
             height: 500,
             shadeDiagonal: false,
@@ -565,11 +565,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Heatmap', tab: 'Charts' });
-          tfvis.render.heatmap(data, surface);
+          tfvis.render.heatmap(surface, data);
 
           // Render to page
           const container = document.getElementById('heatmap-cont');
-          tfvis.render.heatmap(data, container, { width: 500, height: 500 });
+          tfvis.render.heatmap(container, data, { width: 500, height: 500 });
         }
       </script>
 
@@ -588,11 +588,11 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Heatmap w Custom Labels', tab: 'Charts' });
-          tfvis.render.heatmap(data, surface);
+          tfvis.render.heatmap(surface, data);
 
           // Render to page
           const container = document.getElementById('heatmap-cont2');
-          tfvis.render.heatmap(data, container, { width: 500, height: 500 });
+          tfvis.render.heatmap(container, data, { width: 500, height: 500 });
         }
       </script>
 
@@ -611,13 +611,13 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Heatmap w Custom Colormap', tab: 'Charts' });
-          tfvis.render.heatmap(data, surface, {
+          tfvis.render.heatmap(surface, data, {
             colorMap: 'greyscale',
           });
 
           // Render to page
           const container = document.getElementById('heatmap-cont3');
-          tfvis.render.heatmap(data, container, {
+          tfvis.render.heatmap(container, data, {
             colorMap: 'greyscale',
             width: 500,
             height: 500
@@ -640,14 +640,14 @@
 
           // Render to visor
           const surface = tfvis.visor().surface({ name: 'Heatmap', tab: 'Tensor Charts' });
-          tfvis.render.heatmap(data, surface, {
+          tfvis.render.heatmap(surface, data, {
             xLabel: 'Thing',
             yLabel: 'Property',
           });
 
           // Render to page
           const container = document.getElementById('heatmap-cont4');
-          tfvis.render.heatmap(data, container, {
+          tfvis.render.heatmap(container, data, {
             width: 500,
             height: 500,
             xLabel: 'Thing',

--- a/demos/mnist_internals/index.html
+++ b/demos/mnist_internals/index.html
@@ -140,8 +140,10 @@
       </script>
 
       <p>
-        This model is a 'convolutional' model, a common model type for image processing applications. They get their name from the
-        'convolution' operation implemented by some of their layers. There are 3 layers of interest we will focus on in this
+        This model is a 'convolutional' model, a common model type for image processing applications. They get their
+        name from the
+        'convolution' operation implemented by some of their layers. There are 3 layers of interest we will focus on in
+        this
         example:
       </p>
       <ul>
@@ -162,17 +164,21 @@
       <h3>Conv2d1: The first convolution</h3>
 
       <p>
-        Convolutional layers are able to capture local spatial patterns in images due to how the convolution operation works. Convolution
+        Convolutional layers are able to capture local spatial patterns in images due to how the convolution operation
+        works. Convolution
         works similarly to image filters in common image editing tools or
         <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/filter">css filters.</a> In this case they are applied
-        to the image to extract information useful for classification. You can learn more about how convolution works from
+        to the image to extract information useful for classification. You can learn more about how convolution works
+        from
         this
-        <a href="http://setosa.io/ev/image-kernels/">interactive explanation.</a> The training process learns appropriate
+        <a href="http://setosa.io/ev/image-kernels/">interactive explanation.</a> The training process learns
+        appropriate
         'filters' to help with the digit recognition task.
       </p>
 
       <p>
-        Before we take an in depth look at the filters we can get some summary information about this layer using the <code>show.layer</code>        api.
+        Before we take an in depth look at the filters we can get some summary information about this layer using the
+        <code>show.layer</code> api.
       </p>
 
       <p><button id='show-conv1'>Show conv2d_Conv2D1 Details</button></p>
@@ -187,7 +193,8 @@
       </script>
 
       <p>
-        The <em>conv2d_Conv2D1/kernel</em> weight represents the filters used in this convolution. Lets take a look at these
+        The <em>conv2d_Conv2D1/kernel</em> weight represents the filters used in this convolution. Lets take a look at
+        these
         filters and how they transform the output.
       </p>
 
@@ -337,8 +344,10 @@
       <h3>Conv2d2: The second convolution</h3>
 
       <p>
-        The second convolutional layer extracts higher level features from the output of the prior layer. This layer has twice as
-        many filters as the previous convolutional layer. 16 different 'images' will be produced for each input tensor to
+        The second convolutional layer extracts higher level features from the output of the prior layer. This layer has
+        twice as
+        many filters as the previous convolutional layer. 16 different 'images' will be produced for each input tensor
+        to
         this layer. We can see a summary of this layer and then look at the resulting activations.
       </p>
 
@@ -380,7 +389,8 @@
       <h3>dense_Dense1: The Dense layer</h3>
 
       <p>
-        The dense layer is responsible for combining all the information from previous layers by multipying those values with its
+        The dense layer is responsible for combining all the information from previous layers by multipying those values
+        with its
         weights to generate the final prediction.
       </p>
 
@@ -396,7 +406,8 @@
       </script>
 
       <p>
-        The 'activations' from this layer are actually our models final output. 10 values are output that represent the probablility
+        The 'activations' from this layer are actually our models final output. 10 values are output that represent the
+        probablility
         that the image represents that digit (0-9).
       </p>
 
@@ -439,7 +450,7 @@
                 return { index: i, value: d };
               });
             renderImage(imageSurface, imageTensor, { width: 50, height: 50 });
-            tfvis.render.barchart(barchartData, chartSurface, { width: 375, height: 60 });
+            tfvis.render.barchart(chartSurface, barchartData, { width: 375, height: 60 });
           }
         }
 
@@ -452,8 +463,10 @@
     <section>
       <h2>That's it</h2>
       <p>
-        An interesting exercise for you is to reload this page, load the data and then look at the activations <em>before</em>
-        training the model, this will show you what those actications look like when the model is randomly initialized. Compare what
+        An interesting exercise for you is to reload this page, load the data and then look at the activations
+        <em>before</em>
+        training the model, this will show you what those actications look like when the model is randomly initialized.
+        Compare what
         these look like to activations produced after the model is trained.
       </p>
     </section>

--- a/src/render/barchart.ts
+++ b/src/render/barchart.ts
@@ -34,14 +34,14 @@ import {getDrawArea, nextFrame, shallowEquals} from './render_utils';
  *
  * // Render to visor
  * const surface = { name: 'Bar chart', tab: 'Charts' };
- * tfvis.render.barchart(data, surface, {});
+ * tfvis.render.barchart(surface, data);
  * ```
  *
- * @param data Data in the following format, (an array of objects)
- *    [ {index: number, value: number} ... ]
  * @param container An `HTMLElement` or `Surface` in which to draw the bar
  *    chart. Note that the chart expects to have complete control over
  *    the contents of the container and can clear its contents at will.
+ * @param data Data in the following format, (an array of objects)
+ *    [ {index: number, value: number} ... ]
  *
  * @param opts optional parameters
  * @param opts.width width of chart in px
@@ -56,7 +56,7 @@ import {getDrawArea, nextFrame, shallowEquals} from './render_utils';
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function renderBarchart(
-    data: Array<{index: number; value: number;}>, container: Drawable,
+    container: Drawable, data: Array<{index: number; value: number;}>,
     opts: VisOptions = {}): Promise<void> {
   const drawArea = getDrawArea(container);
   const values = data;

--- a/src/render/barchart_test.ts
+++ b/src/render/barchart_test.ts
@@ -33,7 +33,7 @@ describe('renderBarChart', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderBarchart(data, container);
+    await renderBarchart(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -47,10 +47,10 @@ describe('renderBarChart', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderBarchart(data, container);
+    await renderBarchart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
-    await renderBarchart(data, container);
+    await renderBarchart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -63,7 +63,7 @@ describe('renderBarChart', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderBarchart(data, container);
+    await renderBarchart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
     data = [
@@ -72,7 +72,7 @@ describe('renderBarChart', () => {
       {index: 2, value: 150},
     ];
 
-    await renderBarchart(data, container);
+    await renderBarchart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -84,7 +84,7 @@ describe('renderBarChart', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderBarchart(data, container, {width: 400});
+    await renderBarchart(container, data, {width: 400});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);
@@ -99,7 +99,7 @@ describe('renderBarChart', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderBarchart(data, container, {height: 200});
+    await renderBarchart(container, data, {height: 200});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);

--- a/src/render/confusion_matrix.ts
+++ b/src/render/confusion_matrix.ts
@@ -43,7 +43,7 @@ import {getDrawArea} from './render_utils';
  *
  * // Render to visor
  * const surface = { name: 'Confusion Matrix', tab: 'Charts' };
- * tfvis.render.confusionMatrix(data, surface);
+ * tfvis.render.confusionMatrix(surface, data);
  * ```
  *
  * ```js
@@ -58,11 +58,12 @@ import {getDrawArea} from './render_utils';
  *  name: 'Confusion Matrix with Excluded Diagonal', tab: 'Charts'
  * };
  *
- * tfvis.render.confusionMatrix(data, surface, {
+ * tfvis.render.confusionMatrix(surface, data, {
  *   shadeDiagonal: false
  * });
  * ```
  *
+ * @param container An `HTMLElement` or `Surface` in which to draw the chart
  * @param data Data consists of an object with a 'values' property
  *  and a 'labels' property.
  *  {
@@ -78,7 +79,6 @@ import {getDrawArea} from './render_utils';
  *    values: [[80, 23], [56, 94]],
  *    tickLabels: ['dog', 'cat'],
  *  }
- * @param container An `HTMLElement` or `Surface` in which to draw the chart
  * @param opts optional parameters
  * @param opts.shadeDiagonal boolean that controls whether or not to color cells
  * on the diagonal. Defaults to true
@@ -91,7 +91,7 @@ import {getDrawArea} from './render_utils';
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function renderConfusionMatrix(
-    data: ConfusionMatrixData, container: Drawable,
+    container: Drawable, data: ConfusionMatrixData,
     opts: VisOptions&
     {shadeDiagonal?: boolean, showTextOverlay?: boolean} = {}): Promise<void> {
   const options = Object.assign({}, defaultOpts, opts);

--- a/src/render/confusion_matrix_test.ts
+++ b/src/render/confusion_matrix_test.ts
@@ -34,7 +34,7 @@ describe('renderConfusionMatrix', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderConfusionMatrix(data, container);
+    await renderConfusionMatrix(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -46,7 +46,7 @@ describe('renderConfusionMatrix', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderConfusionMatrix(data, container, {shadeDiagonal: true});
+    await renderConfusionMatrix(container, data, {shadeDiagonal: true});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -58,7 +58,7 @@ describe('renderConfusionMatrix', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderConfusionMatrix(data, container);
+    await renderConfusionMatrix(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -70,7 +70,7 @@ describe('renderConfusionMatrix', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderConfusionMatrix(data, container);
+    await renderConfusionMatrix(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
     data = {
@@ -78,7 +78,7 @@ describe('renderConfusionMatrix', () => {
       tickLabels: ['cheese', 'pig', 'font'],
     };
 
-    await renderConfusionMatrix(data, container);
+    await renderConfusionMatrix(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -89,7 +89,7 @@ describe('renderConfusionMatrix', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderConfusionMatrix(data, container, {width: 400});
+    await renderConfusionMatrix(container, data, {width: 400});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);
@@ -103,7 +103,7 @@ describe('renderConfusionMatrix', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderConfusionMatrix(data, container, {height: 200});
+    await renderConfusionMatrix(container, data, {height: 200});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);

--- a/src/render/heatmap.ts
+++ b/src/render/heatmap.ts
@@ -56,6 +56,7 @@ import {getDrawArea} from './render_utils';
  * tfvis.render.heatmap(data, surface);
  * ```
  *
+ * @param container An `HTMLElement` or `Surface` in which to draw the chart
  * @param data Data consists of an object with a 'values' property
  *  and a 'labels' property.
  *  {
@@ -72,7 +73,6 @@ import {getDrawArea} from './render_utils';
  *    xTickLabels: ['dog', 'cat'],
  *    yTickLabels: ['size', 'temperature', 'agility'],
  *  }
- * @param container An `HTMLElement` or `Surface` in which to draw the chart
  * @param opts optional parameters
  * @param opts.colorMap which colormap to use. One of viridis|blues|greyscale.
  *     Defaults to viridis
@@ -88,7 +88,7 @@ import {getDrawArea} from './render_utils';
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function renderHeatmap(
-    data: HeatmapData, container: Drawable,
+    container: Drawable, data: HeatmapData,
     opts: HeatmapOptions = {}): Promise<void> {
   const options = Object.assign({}, defaultOpts, opts);
   const drawArea = getDrawArea(container);

--- a/src/render/heatmap_test.ts
+++ b/src/render/heatmap_test.ts
@@ -35,7 +35,7 @@ describe('renderHeatmap', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHeatmap(data, container);
+    await renderHeatmap(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -47,7 +47,7 @@ describe('renderHeatmap', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHeatmap(data, container);
+    await renderHeatmap(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
@@ -80,7 +80,7 @@ describe('renderHeatmap', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHeatmap(data, container, {colorMap: 'greyscale'});
+    await renderHeatmap(container, data, {colorMap: 'greyscale'});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -91,7 +91,7 @@ describe('renderHeatmap', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHeatmap(data, container, {domain: [0, 30]});
+    await renderHeatmap(container, data, {domain: [0, 30]});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -104,7 +104,7 @@ describe('renderHeatmap', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHeatmap(data, container);
+    await renderHeatmap(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -116,14 +116,14 @@ describe('renderHeatmap', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderHeatmap(data, container);
+    await renderHeatmap(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
     data = {
       values: [[43, 2, 8], [1, 7, 2], [3, 3, 20]],
     };
 
-    await renderHeatmap(data, container);
+    await renderHeatmap(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -133,7 +133,7 @@ describe('renderHeatmap', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHeatmap(data, container, {width: 400});
+    await renderHeatmap(container, data, {width: 400});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);
@@ -146,7 +146,7 @@ describe('renderHeatmap', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHeatmap(data, container, {height: 200});
+    await renderHeatmap(container, data, {height: 200});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);

--- a/src/render/histogram.ts
+++ b/src/render/histogram.ts
@@ -42,12 +42,12 @@ const defaultOpts = {
  * data.push(0);
  *
  * const surface = { name: 'Histogram', tab: 'Charts' };
- * tfvis.render.histogram(data, surface);
+ * tfvis.render.histogram(surface, data);
  * ```
  *
+ * @param container An `HTMLElement`|`Surface` in which to draw the histogram
  * @param data Data in the following format:
  *  `[ {value: number}, ... ]` or `[number]` or `TypedArray`
- * @param container An `HTMLElement`|`Surface` in which to draw the histogram
  * @param opts optional parameters
  * @param opts.width width of chart in px
  * @param opts.height height of chart in px
@@ -70,7 +70,7 @@ const defaultOpts = {
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function renderHistogram(
-    data: Array<{value: number}>|number[]|TypedArray, container: HTMLElement,
+    container: HTMLElement, data: Array<{value: number}>|number[]|TypedArray,
     opts: HistogramOpts = {}) {
   const values = prepareData(data);
 
@@ -209,7 +209,7 @@ function renderStats(
     vals.push(`${format(stats.numInfs)} ${infPct}`);
   }
 
-  renderTable({headers, values: [vals]}, container, opts);
+  renderTable(container, {headers, values: [vals]}, opts);
 }
 
 /**

--- a/src/render/histogram_test.ts
+++ b/src/render/histogram_test.ts
@@ -35,7 +35,7 @@ describe('renderHistogram', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('table').length).toBe(1);
@@ -49,7 +49,7 @@ describe('renderHistogram', () => {
     const data = [50, 100, 100];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('table').length).toBe(1);
@@ -63,7 +63,7 @@ describe('renderHistogram', () => {
     const data = new Int32Array([50, 100, 100]);
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('table').length).toBe(1);
@@ -82,10 +82,10 @@ describe('renderHistogram', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -98,7 +98,7 @@ describe('renderHistogram', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
     data = [
@@ -107,7 +107,7 @@ describe('renderHistogram', () => {
       {value: 150},
     ];
 
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -124,7 +124,7 @@ describe('renderHistogram', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHistogram(data, container);
+    await renderHistogram(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('table').length).toBe(1);
@@ -144,7 +144,7 @@ describe('renderHistogram', () => {
 
     const container = document.getElementById('container') as HTMLElement;
     expect(async () => {
-      await renderHistogram(data, container);
+      await renderHistogram(container, data);
     }).not.toThrow();
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
@@ -167,7 +167,7 @@ describe('renderHistogram', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHistogram(data, container, {stats});
+    await renderHistogram(container, data, {stats});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('table').length).toBe(1);
@@ -190,7 +190,7 @@ describe('renderHistogram', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHistogram(data, container, {width: 400});
+    await renderHistogram(container, data, {width: 400});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);
@@ -205,7 +205,7 @@ describe('renderHistogram', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderHistogram(data, container, {height: 200});
+    await renderHistogram(container, data, {height: 200});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);

--- a/src/render/linechart.ts
+++ b/src/render/linechart.ts
@@ -36,8 +36,8 @@ import {getDrawArea} from './render_utils';
  * const series = ['First', 'Second'];
  * const data = { values: [series1, series2], series }
  *
- * const surface = tfvis.visor().surface({ name: 'Line chart', tab: 'Charts' });
- * tfvis.render.linechart(data, surface);
+ * const surface = { name: 'Line chart', tab: 'Charts' };
+ * tfvis.render.linechart(surface, data);
  * ```
  *
  * ```js
@@ -49,9 +49,10 @@ import {getDrawArea} from './render_utils';
  *
  * // Render to visor
  * const surface = { name: 'Zoomed Line Chart', tab: 'Charts' };
- * tfvis.render.linechart(data, surface, { zoomToFit: true });
+ * tfvis.render.linechart(surface, data, { zoomToFit: true });
  * ```
  *
+ * @param container An HTMLElement in which to draw the chart
  * @param data Data in the following format
  *  {
  *    // A nested array of objects each with an x and y property,
@@ -64,7 +65,6 @@ import {getDrawArea} from './render_utils';
  *    // Optional
  *    series: string[]
  *  }
- * @param container An HTMLElement in which to draw the chart
  * @param opts optional parameters
  * @param opts.width width of chart in px
  * @param opts.height height of chart in px
@@ -80,8 +80,9 @@ import {getDrawArea} from './render_utils';
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function renderLinechart(
+    container: Drawable,
     data: {values: Point2D[][]|Point2D[], series?: string[]},
-    container: Drawable, opts: XYPlotOptions = {}): Promise<void> {
+    opts: XYPlotOptions = {}): Promise<void> {
   let inputArray = data.values;
   const _series = data.series == null ? [] : data.series;
 

--- a/src/render/linechart_test.ts
+++ b/src/render/linechart_test.ts
@@ -35,7 +35,7 @@ describe('renderLineChart', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderLinechart(data, container);
+    await renderLinechart(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -58,7 +58,7 @@ describe('renderLineChart', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderLinechart(data, container);
+    await renderLinechart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -81,7 +81,7 @@ describe('renderLineChart', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderLinechart(data, container);
+    await renderLinechart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -104,7 +104,7 @@ describe('renderLineChart', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderLinechart(data, container);
+    await renderLinechart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
     data = {
@@ -125,7 +125,7 @@ describe('renderLineChart', () => {
       series: ['First', 'Second'],
     };
 
-    await renderLinechart(data, container);
+    await renderLinechart(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -139,7 +139,7 @@ describe('renderLineChart', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderLinechart(data, container, {width: 400});
+    await renderLinechart(container, data, {width: 400});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);
@@ -156,7 +156,7 @@ describe('renderLineChart', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderLinechart(data, container, {height: 200});
+    await renderLinechart(container, data, {height: 200});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);

--- a/src/render/scatterplot.ts
+++ b/src/render/scatterplot.ts
@@ -37,9 +37,10 @@ import {getDrawArea} from './render_utils';
  * const data = { values: [series1, series2], series }
  *
  * const surface = { name: 'Scatterplot', tab: 'Charts' };
- * tfvis.render.scatterplot(data, surface);
+ * tfvis.render.scatterplot(surface, data);
  * ```
  *
+ * @param container An HTMLElement in which to draw the chart
  * @param data Data in the following format
  *  {
  *    // A nested array of objects each with an x and y property,
@@ -52,7 +53,6 @@ import {getDrawArea} from './render_utils';
  *    // Optional
  *    series: string[]
  *  }
- * @param container An HTMLElement in which to draw the chart
  * @param opts optional parameters
  * @param opts.width width of chart in px
  * @param opts.height height of chart in px
@@ -70,8 +70,9 @@ import {getDrawArea} from './render_utils';
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function renderScatterplot(
+    container: Drawable,
     data: {values: Point2D[][]|Point2D[], series?: string[]},
-    container: Drawable, opts: XYPlotOptions = {}): Promise<void> {
+    opts: XYPlotOptions = {}): Promise<void> {
   let _values = data.values;
   const _series = data.series == null ? [] : data.series;
 

--- a/src/render/scatterplot_tests.ts
+++ b/src/render/scatterplot_tests.ts
@@ -35,7 +35,7 @@ describe('renderScatterplot', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderScatterplot(data, container);
+    await renderScatterplot(container, data);
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
@@ -58,10 +58,10 @@ describe('renderScatterplot', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderScatterplot(data, container);
+    await renderScatterplot(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
-    await renderScatterplot(data, container);
+    await renderScatterplot(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -84,7 +84,7 @@ describe('renderScatterplot', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderScatterplot(data, container);
+    await renderScatterplot(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -107,7 +107,7 @@ describe('renderScatterplot', () => {
 
     const container = document.getElementById('container') as HTMLElement;
 
-    await renderScatterplot(data, container);
+    await renderScatterplot(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
 
     data = {
@@ -128,7 +128,7 @@ describe('renderScatterplot', () => {
       series: ['First', 'Second'],
     };
 
-    await renderScatterplot(data, container);
+    await renderScatterplot(container, data);
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
@@ -142,7 +142,7 @@ describe('renderScatterplot', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderScatterplot(data, container, {width: 400});
+    await renderScatterplot(container, data, {width: 400});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);
@@ -159,7 +159,7 @@ describe('renderScatterplot', () => {
     };
 
     const container = document.getElementById('container') as HTMLElement;
-    await renderScatterplot(data, container, {height: 200});
+    await renderScatterplot(container, data, {height: 200});
 
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
     expect(document.querySelectorAll('canvas').length).toBe(1);

--- a/src/render/table.ts
+++ b/src/render/table.ts
@@ -39,7 +39,7 @@ import {getDrawArea} from './render_utils';
  * ];
  *
  * const surface = { name: 'Table', tab: 'Charts' };
- * tfvis.render.table({ headers, values }, surface);
+ * tfvis.render.table(surface, { headers, values });
  * ```
  *
  * @param data Data in the following format
@@ -62,8 +62,9 @@ import {getDrawArea} from './render_utils';
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export function renderTable(
+    container: Drawable,
     // tslint:disable-next-line:no-any
-    data: {headers: string[], values: any[][]}, container: Drawable,
+    data: {headers: string[], values: any[][]},
     opts: {fontSize?: number} = {}) {
   if (data && data.headers == null) {
     throw new Error('Data to render must have a "headers" property');

--- a/src/render/table_test.ts
+++ b/src/render/table_test.ts
@@ -44,7 +44,7 @@ describe('renderTable', () => {
     ];
 
     const container = document.getElementById('container') as HTMLElement;
-    renderTable({headers, values}, container);
+    renderTable(container, {headers, values});
 
     expect(document.querySelectorAll('.tf-table').length).toBe(1);
     expect(document.querySelectorAll('.tf-table thead tr').length).toBe(1);
@@ -82,7 +82,7 @@ describe('renderTable', () => {
     const headers: string[] = [];
     const values: string[][] = [];
 
-    expect(() => renderTable({headers, values}, container)).not.toThrow();
+    expect(() => renderTable(container, {headers, values})).not.toThrow();
 
     expect(document.querySelectorAll('.tf-table').length).toBe(1);
     expect(document.querySelectorAll('.tf-table thead tr').length).toBe(1);

--- a/src/show/history.ts
+++ b/src/show/history.ts
@@ -166,7 +166,7 @@ export async function history(
       }
     }
 
-    const done = renderLinechart({values, series}, subContainer, options);
+    const done = renderLinechart(subContainer, {values, series}, options);
     renderPromises.push(done);
   }
   await Promise.all(renderPromises);

--- a/src/show/model.ts
+++ b/src/show/model.ts
@@ -71,7 +71,7 @@ export async function modelSummary(container: Drawable, model: tf.Model) {
            l.trainable,
   ]);
 
-  renderTable({headers, values}, drawArea);
+  renderTable(drawArea, {headers, values});
 }
 
 /**
@@ -124,7 +124,7 @@ export async function layer(container: Drawable, layer: Layer) {
           [l.name, l.shape, l.stats.min, l.stats.max, l.weight.size,
            l.stats.numZeros, l.stats.numNans, l.stats.numInfs]);
 
-  renderTable({headers, values: detailValues}, weightsInfoSurface);
+  renderTable(weightsInfoSurface, {headers, values: detailValues});
 
   const histogramSelectorSurface = subSurface(drawArea, 'select-layer');
   const layerValuesHistogram = subSurface(drawArea, 'param-distribution');
@@ -134,7 +134,7 @@ export async function layer(container: Drawable, layer: Layer) {
     const weights = await layer.weight.data();
 
     renderHistogram(
-        weights, layerValuesHistogram, {height: 150, width: 460, stats: false});
+        layerValuesHistogram, weights, {height: 150, width: 460, stats: false});
   };
 
   addHistogramSelector(

--- a/src/show/quality.ts
+++ b/src/show/quality.ts
@@ -63,7 +63,7 @@ export async function showPerClassAccuracy(
     values.push([label, classAcc.accuracy, classAcc.count]);
   }
 
-  return renderTable({headers, values}, drawArea);
+  return renderTable(drawArea, {headers, values});
 }
 
 /**
@@ -101,7 +101,7 @@ export async function showConfusionMatrix(
     tickLabels: classLabels,
   };
 
-  return renderConfusionMatrix(confusionMatrixData, drawArea, {
+  return renderConfusionMatrix(drawArea, confusionMatrixData, {
     height: 450,
   });
 }

--- a/src/show/tensor.ts
+++ b/src/show/tensor.ts
@@ -45,5 +45,5 @@ export async function valuesDistribution(container: Drawable, tensor: Tensor) {
   const drawArea = getDrawArea(container);
   const stats = await tensorStats(tensor);
   const values = await tensor.data();
-  renderHistogram(values, drawArea, {height: 150, stats});
+  renderHistogram(drawArea, values, {height: 150, stats});
 }


### PR DESCRIPTION
This make the param order of render.* functions match show.*. They both now follow a container first convention.

BREAKING.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/56)
<!-- Reviewable:end -->
