### PR TITLE
BREAKING remove show.confusionMatrix in favor of render.confusionMatrix

### DIFF
--- a/demos/mnist/index.html
+++ b/demos/mnist/index.html
@@ -304,7 +304,10 @@
             const [preds, labels] = doPrediction();
             const confusionMatrix = await tfvis.metrics.confusionMatrix(labels, preds);
             const container = { name: 'Confusion Matrix', tab: 'Evaluation' };
-            tfvis.show.confusionMatrix(container, confusionMatrix, classNames);
+            tfvis.render.confusionMatrix(container, {
+              values: confusionMatrix,
+              tickLabels: classNames,
+            });
 
             labels.dispose();
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import {renderScatterplot} from './render/scatterplot';
 import {renderTable} from './render/table';
 import {fitCallbacks, history} from './show/history';
 import {layer, modelSummary} from './show/model';
-import {showConfusionMatrix, showPerClassAccuracy} from './show/quality';
+import {showPerClassAccuracy} from './show/quality';
 import {valuesDistribution} from './show/tensor';
 import {accuracy, confusionMatrix, perClassAccuracy} from './util/math';
 
@@ -48,7 +48,6 @@ const show = {
   history,
   fitCallbacks,
   perClassAccuracy: showPerClassAccuracy,
-  confusionMatrix: showConfusionMatrix,
   valuesDistribution,
   layer,
   modelSummary,

--- a/src/render/confusion_matrix.ts
+++ b/src/render/confusion_matrix.ts
@@ -255,6 +255,7 @@ const defaultOpts = {
   shadeDiagonal: true,
   fontSize: 12,
   showTextOverlay: true,
+  height: 400,
 };
 
 interface MatrixEntry {

--- a/src/show/quality.ts
+++ b/src/show/quality.ts
@@ -15,10 +15,9 @@
  * =============================================================================
  */
 
-import {renderConfusionMatrix} from '../render/confusion_matrix';
 import {getDrawArea} from '../render/render_utils';
 import {renderTable} from '../render/table';
-import {ConfusionMatrixData, Drawable} from '../types';
+import {Drawable} from '../types';
 
 /**
  * Renders a per class accuracy table for classification task evaluation
@@ -64,44 +63,4 @@ export async function showPerClassAccuracy(
   }
 
   return renderTable(drawArea, {headers, values});
-}
-
-/**
- * Renders a confusion matrix for classification task evaluation
- *
- * ```js
- * const labels = tf.tensor1d([0, 0, 1, 1, 2, 2, 2, 3 ,3 ,3, 4, 4]);
- * const predictions = tf.tensor1d([0, 0, 1, 0, 2, 3, 1, 3 ,4 ,3, 2, 2]);
- *
- * const matrix = await tfvis.metrics.confusionMatrix(labels, predictions);
- *
- * const container = {name: 'Confusion Matrix', tab: 'Evaluation'};
- * const categories = ['cat', 'dog', 'mouse', 'bird', 'fish'];
- * await tfvis.show.confusionMatrix(container, matrix, categories);
- * ```
- *
- * @param container A `{name: string, tab?: string}` object specifying which
- * surface to render to.
- * @param confusionMatrix A nested array of numbers with the confusion matrix
- * values. See metrics.confusionMatrix for details on how to generate this.
- * @param classLabels An array of string labels for the classes in
- * `confusionMatrix`. Optional.
- *
- */
-/**
- * @doc {heading: 'Models & Tensors', subheading: 'Model Evaluation', namespace:
- * 'show'}
- */
-export async function showConfusionMatrix(
-    container: Drawable, confusionMatrix: number[][], classLabels?: string[]) {
-  const drawArea = getDrawArea(container);
-
-  const confusionMatrixData: ConfusionMatrixData = {
-    values: confusionMatrix,
-    tickLabels: classLabels,
-  };
-
-  return renderConfusionMatrix(drawArea, confusionMatrixData, {
-    height: 450,
-  });
 }

--- a/src/show/quality_test.ts
+++ b/src/show/quality_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {showConfusionMatrix, showPerClassAccuracy} from './quality';
+import {showPerClassAccuracy} from './quality';
 
 describe('perClassAccuracy', () => {
   beforeEach(() => {
@@ -42,32 +42,5 @@ describe('perClassAccuracy', () => {
     ];
     await showPerClassAccuracy(container, acc);
     expect(document.querySelectorAll('table').length).toBe(1);
-  });
-});
-
-describe('confusionMatrix', () => {
-  beforeEach(() => {
-    document.body.innerHTML = '<div id="container"></div>';
-  });
-
-  it('renders a confusion matrix', async () => {
-    const container = {name: 'Test'};
-    const matrix = [
-      [20, 3],
-      [6, 32],
-    ];
-    const labels = ['cat', 'dog'];
-    await showConfusionMatrix(container, matrix, labels);
-    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
-  });
-
-  it('renders a confusion matrix without explicit labels', async () => {
-    const container = {name: 'Test'};
-    const matrix = [
-      [20, 3],
-      [6, 32],
-    ];
-    await showConfusionMatrix(container, matrix);
-    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 });


### PR DESCRIPTION
remove show.confusionMatrix in favor of render.confusionMatrix as the show method doesn't do much extra work. Closes https://github.com/tensorflow/tfjs/issues/1294

BREAKING

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/57)
<!-- Reviewable:end -->
