### PR TITLE
Don't publish _test.ts files on NPM.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .vscode/
 .rpt2_cache/
+src/**/*_test.ts
 demos/
 scripts/
 models/


### PR DESCRIPTION
There is no need to publish the src/**/*_test.ts files.

It causes the tests to execute in dependent packages when those tests are run. This also decreases the NPM package size.

See #1380