### PR TITLE
Remove firefox and safari from local testing.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,7 +46,7 @@ module.exports = function(config) {
     },
     karmaTypescriptConfig,
     reporters: ['progress', 'karma-typescript'],
-    browsers: ['Chrome', 'Firefox', 'Safari'],
+    browsers: ['Chrome'],
     browserStack: {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_KEY


### PR DESCRIPTION
We have coverage on browserstack and this will make local testing faster (this is what we do in core).