### PR TITLE
Improve docs and types

### DIFF
--- a/src/components/surface.tsx
+++ b/src/components/surface.tsx
@@ -18,7 +18,7 @@
 import { h, Component } from 'preact';
 import { css } from 'glamor';
 import { tachyons as tac } from 'glamor-tachyons';
-import { SurfaceInfoStrict, CSSOptions } from '../types';
+import { SurfaceInfoStrict, StyleOptions } from '../types';
 
 // Internal Props
 interface SurfaceProps extends SurfaceInfoStrict {
@@ -33,7 +33,7 @@ interface SurfaceProps extends SurfaceInfoStrict {
  */
 export class SurfaceComponent extends Component<SurfaceProps> {
 
-  static defaultStyles: Partial<CSSOptions> = {
+  static defaultStyles: Partial<StyleOptions> = {
     maxWidth: '580px',
     maxHeight: '580px',
     height: 'auto',

--- a/src/render/barchart.ts
+++ b/src/render/barchart.ts
@@ -36,22 +36,10 @@ import {getDrawArea, nextFrame, shallowEquals} from './render_utils';
  * tfvis.render.barchart(surface, data);
  * ```
  *
- * @param container An `HTMLElement` or `Surface` in which to draw the bar
- *    chart. Note that the chart expects to have complete control over
- *    the contents of the container and can clear its contents at will.
  * @param data Data in the following format, (an array of objects)
- *    [ {index: number, value: number} ... ]
- *
- * @param opts optional parameters
- * @param opts.width width of chart in px
- * @param opts.height height of chart in px
- * @param opts.xLabel label for x-axis, set to null to hide the
- * @param opts.yLabel label for y-axis, set to null to hide the
- * @param opts.fontSize fontSize in pixels for text in the chart
+ *    `[ {index: number, value: number} ... ]`
  *
  * @returns Promise - indicates completion of rendering
- *
- *
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function barchart(

--- a/src/render/confusion_matrix.ts
+++ b/src/render/confusion_matrix.ts
@@ -17,7 +17,8 @@
 
 import embed, {Mode, VisualizationSpec} from 'vega-embed';
 
-import {ConfusionMatrixData, Drawable, VisOptions,} from '../types';
+import {ConfusionMatrixData, ConfusionMatrixOptions, Drawable,} from '../types';
+
 import {getDrawArea} from './render_utils';
 
 /**
@@ -62,38 +63,11 @@ import {getDrawArea} from './render_utils';
  *   shadeDiagonal: false
  * });
  * ```
- *
- * @param container An `HTMLElement` or `Surface` in which to draw the chart
- * @param data Data consists of an object with a 'values' property
- *  and a 'labels' property.
- *  {
- *    // a matrix of numbers representing counts for each (label, prediction)
- *    // pair
- *    values: number[][],
- *
- *    // Human readable labels for each class in the matrix. Optional
- *    tickLabels?: string[]
- *  }
- *  e.g.
- *  {
- *    values: [[80, 23], [56, 94]],
- *    tickLabels: ['dog', 'cat'],
- *  }
- * @param opts optional parameters
- * @param opts.shadeDiagonal boolean that controls whether or not to color cells
- * on the diagonal. Defaults to true
- * @param opts.showTextOverlay boolean that controls whether or not to render
- * the values of each cell as text. Defaults to true
- * @param opts.width width of chart in px
- * @param opts.height height of chart in px
- * @param opts.fontSize fontSize in pixels for text in the chart
- *
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function confusionMatrix(
     container: Drawable, data: ConfusionMatrixData,
-    opts: VisOptions&
-    {shadeDiagonal?: boolean, showTextOverlay?: boolean} = {}): Promise<void> {
+    opts: ConfusionMatrixOptions = {}): Promise<void> {
   const options = Object.assign({}, defaultOpts, opts);
   const drawArea = getDrawArea(container);
 

--- a/src/render/heatmap.ts
+++ b/src/render/heatmap.ts
@@ -27,15 +27,15 @@ import {getDrawArea} from './render_utils';
  * Renders a heatmap.
  *
  * ```js
- * const rows = 50;
- * const cols = 20;
+ * const cols = 50;
+ * const rows = 20;
  * const values = [];
- * for (let i = 0; i < rows; i++) {
- *   const row = []
- *   for (let j = 0; j < cols; j++) {
- *     row.push(i * j)
+ * for (let i = 0; i < cols; i++) {
+ *   const col = []
+ *   for (let j = 0; j < rows; j++) {
+ *     col.push(i * j)
  *   }
- *   values.push(row);
+ *   values.push(col);
  * }
  * const data = { values };
  *
@@ -55,35 +55,6 @@ import {getDrawArea} from './render_utils';
  * const surface = { name: 'Heatmap w Custom Labels', tab: 'Charts' };
  * tfvis.render.heatmap(surface, data);
  * ```
- *
- * @param container An `HTMLElement` or `Surface` in which to draw the chart
- * @param data Data consists of an object with a 'values' property
- *  and a 'labels' property.
- *  {
- *    // a matrix of numbers
- *    values: number[][]|Tensor2D,
- *
- *    // Human readable labels for each class in the matrix. Optional
- *    xTickLabels?: string[]
- *    yTickLabels?: string[]
- *  }
- *  e.g.
- *  {
- *    values: [[80, 23, 50], [56, 94, 39]],
- *    xTickLabels: ['dog', 'cat'],
- *    yTickLabels: ['size', 'temperature', 'agility'],
- *  }
- * @param opts optional parameters
- * @param opts.colorMap which colormap to use. One of viridis|blues|greyscale.
- *     Defaults to viridis
- * @param opts.domain a two element array representing a custom output domain
- *     for the color scale. Useful if you want to plot multiple heatmaps using
- *     the same scale.
- * @param opts.xLabel label for x axis
- * @param opts.yLabel label for y axis
- * @param opts.width width of chart in px
- * @param opts.height height of chart in px
- * @param opts.fontSize fontSize in pixels for text in the chart
  *
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */

--- a/src/render/histogram.ts
+++ b/src/render/histogram.ts
@@ -18,7 +18,7 @@
 import {format as d3Format} from 'd3-format';
 import embed, {Mode, VisualizationSpec} from 'vega-embed';
 
-import {HistogramOpts, HistogramStats, TypedArray} from '../types';
+import {Drawable, HistogramOpts, HistogramStats, TypedArray} from '../types';
 import {subSurface} from '../util/dom';
 import {arrayStats} from '../util/math';
 
@@ -44,33 +44,10 @@ const defaultOpts = {
  * const surface = { name: 'Histogram', tab: 'Charts' };
  * tfvis.render.histogram(surface, data);
  * ```
- *
- * @param container An `HTMLElement`|`Surface` in which to draw the histogram
- * @param data Data in the following format:
- *  `[ {value: number}, ... ]` or `[number]` or `TypedArray`
- * @param opts optional parameters
- * @param opts.width width of chart in px
- * @param opts.height height of chart in px
- * @param opts.fontSize fontSize in pixels for text in the chart
- * @param opts.maxBins maximimum number of bins to use in histogram
- * @param opts.stats summary statistics to show. These will be computed
- *    internally if no stats are passed. Pass `false` to not compute any stats.
- *    Callers are allowed to pass in their own stats as in some cases they
- *    may be able to compute them more efficiently.
- *
- *    Stats should have the following format
- *    {
- *      numVals?: number,
- *      min?: number,
- *      max?: number,
- *      numZeros?: number,
- *      numNans?: number
- *    }
- *
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function histogram(
-    container: HTMLElement, data: Array<{value: number}>|number[]|TypedArray,
+    container: Drawable, data: Array<{value: number}>|number[]|TypedArray,
     opts: HistogramOpts = {}) {
   const values = prepareData(data);
 

--- a/src/render/linechart.ts
+++ b/src/render/linechart.ts
@@ -17,7 +17,7 @@
 
 import embed, {Mode, VisualizationSpec} from 'vega-embed';
 
-import {Drawable, Point2D, XYPlotOptions} from '../types';
+import {Drawable, Point2D, XYPlotData, XYPlotOptions} from '../types';
 
 import {getDrawArea} from './render_utils';
 
@@ -52,36 +52,10 @@ import {getDrawArea} from './render_utils';
  * tfvis.render.linechart(surface, data, { zoomToFit: true });
  * ```
  *
- * @param container An HTMLElement in which to draw the chart
- * @param data Data in the following format
- *  {
- *    // A nested array of objects each with an x and y property,
- *    // one per series.
- *    // If you only have one series to render you can just pass an array
- *    // of objects with x, y properties
- *    values: {x: number, y: number}[][]
- *
- *    // An array of strings with the names of each series passed above.
- *    // Optional
- *    series: string[]
- *  }
- * @param opts optional parameters
- * @param opts.width width of chart in px
- * @param opts.height height of chart in px
- * @param opts.xLabel label for x axis
- * @param opts.yLabel label for y axis
- * @param opts.fontSize fontSize in pixels for text in the chart
- * @param opts.zoomToFit a boolean indicating whether to allow non-zero
- * baselines setting this to true allows the line chart to take up more room in
- * the plot.
- * @param opts.yAxisDomain array of two numbers indicating the domain of the y
- * axis. This is overriden by zoomToFit
- *
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function linechart(
-    container: Drawable,
-    data: {values: Point2D[][]|Point2D[], series?: string[]},
+    container: Drawable, data: XYPlotData,
     opts: XYPlotOptions = {}): Promise<void> {
   let inputArray = data.values;
   const _series = data.series == null ? [] : data.series;

--- a/src/render/scatterplot.ts
+++ b/src/render/scatterplot.ts
@@ -17,7 +17,7 @@
 
 import embed, {Mode, VisualizationSpec} from 'vega-embed';
 
-import {Drawable, Point2D, XYPlotOptions} from '../types';
+import {Drawable, Point2D, XYPlotData, XYPlotOptions} from '../types';
 
 import {getDrawArea} from './render_utils';
 
@@ -40,38 +40,10 @@ import {getDrawArea} from './render_utils';
  * tfvis.render.scatterplot(surface, data);
  * ```
  *
- * @param container An HTMLElement in which to draw the chart
- * @param data Data in the following format
- *  {
- *    // A nested array of objects each with an x and y property,
- *    // one per series.
- *    // If you only have one series to render you can just pass an array
- *    // of objects with x, y properties
- *    values: {x: number, y: number}[][]
- *
- *    // An array of strings with the names of each series passed above.
- *    // Optional
- *    series: string[]
- *  }
- * @param opts optional parameters
- * @param opts.width width of chart in px
- * @param opts.height height of chart in px
- * @param opts.xLabel label for x axis
- * @param opts.yLabel label for y axis
- * @param opts.fontSize fontSize in pixels for text in the chart
- * @param opts.zoomToFit a boolean indicating whether to allow excluding zero
- * from the domain of the charts axes setting this to true allows the points to
- * take up more room in the plot.
- * @param opts.xAxisDomain array of two numbers indicating the domain of the x
- * axis. This is overriden by zoomToFit
- * @param opts.yAxisDomain array of two numbers indicating the domain of the y
- * axis. This is overriden by zoomToFit
- *
  */
 /** @doc {heading: 'Charts', namespace: 'render'} */
 export async function scatterplot(
-    container: Drawable,
-    data: {values: Point2D[][]|Point2D[], series?: string[]},
+    container: Drawable, data: XYPlotData,
     opts: XYPlotOptions = {}): Promise<void> {
   let _values = data.values;
   const _series = data.series == null ? [] : data.series;

--- a/src/render/table.ts
+++ b/src/render/table.ts
@@ -101,15 +101,14 @@ export function table(
   //
   const format = d3Format(',.4~f');
 
-  const rows = table.select('tbody').selectAll('tr').data((data.values as []));
+  const rows = table.select('tbody').selectAll('tr').data(data.values);
   const rowsEnter = rows.enter().append('tr');
 
   // Nested selection to add individual cells
   const cellStyle = css({...tac('pa1 bb b--black-20')});
   const cells = rows.merge(rowsEnter).selectAll('td').data(d => d);
   const cellsEnter = cells.enter().append('td').attr('class', `${cellStyle}`);
-  cells.merge(cellsEnter)
-      .html((d: number|string) => typeof d === 'number' ? format(d) : d);
+  cells.merge(cellsEnter).html(d => typeof d === 'number' ? format(d) : d);
 
   cells.exit().remove();
   rows.exit().remove();

--- a/src/render/table.ts
+++ b/src/render/table.ts
@@ -19,7 +19,7 @@ import {format as d3Format} from 'd3-format';
 import {select as d3Select} from 'd3-selection';
 import {css} from 'glamor';
 import {tachyons as tac} from 'glamor-tachyons';
-import {Drawable} from '../types';
+import {Drawable, TableData} from '../types';
 import {getDrawArea} from './render_utils';
 
 /**
@@ -42,21 +42,6 @@ import {getDrawArea} from './render_utils';
  * tfvis.render.table(surface, { headers, values });
  * ```
  *
- * @param data Data in the following format
- *    {
- *      headers: string[],
- *      values:  any[][],
- *    }
- *    data.headers are the column names
- *    data.values is an array of arrays (one for  each row). The inner
- *    array length usually matches the length of data.headers. Usually
- *    the values are strings or numbers, these are inserted as html
- *    content so html strings are also supported.
- *
- * @param container An `HTMLElement` or `Surface` in which to draw the table.
- *    Note that the chart expects to have complete control over
- *    the contents of the container and can clear its contents
- *    at will.
  * @param opts.fontSize fontSize in pixels for text in the chart.
  *
  */
@@ -64,8 +49,7 @@ import {getDrawArea} from './render_utils';
 export function table(
     container: Drawable,
     // tslint:disable-next-line:no-any
-    data: {headers: string[], values: any[][]},
-    opts: {fontSize?: number} = {}) {
+    data: TableData, opts: {fontSize?: number} = {}) {
   if (data && data.headers == null) {
     throw new Error('Data to render must have a "headers" property');
   }
@@ -117,14 +101,15 @@ export function table(
   //
   const format = d3Format(',.4~f');
 
-  const rows = table.select('tbody').selectAll('tr').data(data.values);
+  const rows = table.select('tbody').selectAll('tr').data((data.values as []));
   const rowsEnter = rows.enter().append('tr');
 
   // Nested selection to add individual cells
   const cellStyle = css({...tac('pa1 bb b--black-20')});
   const cells = rows.merge(rowsEnter).selectAll('td').data(d => d);
   const cellsEnter = cells.enter().append('td').attr('class', `${cellStyle}`);
-  cells.merge(cellsEnter).html(d => typeof d === 'number' ? format(d) : d);
+  cells.merge(cellsEnter)
+      .html((d: number|string) => typeof d === 'number' ? format(d) : d);
 
   cells.exit().remove();
   rows.exit().remove();

--- a/src/show/history.ts
+++ b/src/show/history.ts
@@ -92,23 +92,12 @@ import {subSurface} from '../util/dom';
  * });
  * ```
  *
- * @param container A `{name: string, tab?: string}` object specifying which
- *  surface to render to.
  * @param history A history like object. Either a tfjs-layers `History` object
  *  or an array of tfjs-layers `Logs` objects.
  * @param metrics An array of strings for each metric to plot from the history
  *  object. Using this allows you to control which metrics appear on the same
  *  plot.
- * @param opts Optional parameters for the line charts. See the opts parameter
- *  for render.linechart for details. Notably for 'accuracy' related plots
- *  the domain of the yAxis will always by 0-1, i.e. zoomToFit and yAxisDomain
- *  options are ignored.
- * @param opts.zoomToFitAccuracy a boolean controlling whether to 'zoomToFit'
- *  accuracy plots as well. Constraining the y axis domain of an accuracy plot
- *  to exactly 0-1 is desireable most of the time. However there may be cases,
- *  such as when doing transfer learning, where more resolution is desired. Set
- *  zoomToFitAccuracy to true to turn on zoomToFit for accuracy plots.
- *
+ * @param opts Optional parameters for the line charts.
  */
 /**
  * @doc {heading: 'Models & Tensors', subheading: 'Model Training', namespace:
@@ -257,21 +246,8 @@ function getValues(
  * });
  * ```
  *
- * @param container A `{name: string, tab?: string}` object specifying which
- *  surface to render to.
  * @param metrics List of metrics to plot.
- * @param opts Optional parameters for the line charts. See the opts parameter
- *  for render.linechart for details. Notably for 'accuracy' related plots
- *  the domain of the yAxis will always by 0-1, i.e. zoomToFit and yAxisDomain
- *  options are ignored.
- * @param opts.zoomToFitAccuracy a boolean controlling whether to 'zoomToFit'
- *  accuracy plots as well. Constraining the y axis domain of an accuracy plot
- *  to exactly 0-1 is desireable most of the time. However there may be cases,
- *  such as when doing transfer learning, where more resolution is desired. Set
- *  zoomToFitAccuracy to true to turn on zoomToFit for accuracy plots.
- * @param opts.callbacks Array of strings with callback names. Valid options
- *  are 'onEpochEnd' and 'onBatchEnd'. Defaults to ['onEpochEnd', 'onBatchEnd'].
- *
+ * @param opts Optional parameters
  */
 /**
  * @doc {heading: 'Models & Tensors', subheading: 'Model Training', namespace:
@@ -343,6 +319,11 @@ interface FitCallbackLogs {
 }
 
 interface FitCallbackOptions extends HistoryOptions {
+  /**
+   * Array of callback names. Valid options
+   * are 'onEpochEnd' and 'onBatchEnd'. Defaults to ['onEpochEnd',
+   * 'onBatchEnd'].
+   */
   callbacks?: string[];
 }
 

--- a/src/show/model.ts
+++ b/src/show/model.ts
@@ -40,10 +40,6 @@ import {tensorStats} from '../util/math';
  * tfvis.show.modelSummary(surface, model);
  * ```
  *
- * @param container A `{name: string, tab?: string}` object specifying which
- *     surface to render to.
- * @param model
- *
  */
 /**
  * @doc {
@@ -89,10 +85,6 @@ export async function modelSummary(container: Drawable, model: tf.LayersModel) {
  * const surface = { name: 'Layer Summary', tab: 'Model Inspection'};
  * tfvis.show.layer(surface, model.getLayer(undefined, 1));
  * ```
- *
- * @param container A `{name: string, tab?: string}` object specifying which
- *     surface to render to.
- * @param layer a `tf.layers.Layer`
  *
  */
 /**

--- a/src/show/tensor.ts
+++ b/src/show/tensor.ts
@@ -32,10 +32,6 @@ import {tensorStats} from '../util/math';
  * await tfvis.show.valuesDistribution(surface, tensor);
  * ```
  *
- * @param container A `{name: string, tab?: string}` object specifying which
- *  surface to render to.
- * @param tensor the input tensor
- *
  */
 /**
  * @doc {heading: 'Models & Tensors', subheading: 'Model Inspection', namespace:

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,14 +73,17 @@ export interface SurfaceInfoStrict extends SurfaceInfo {
 /**
  * Style properties are generally optional as components will specify defaults.
  */
-export type StyleOptions = Partial<CSSOptions>;
-export interface CSSOptions {
-  width: string;
-  height: string;
-  maxWidth: string;
-  maxHeight: string;
+export interface StyleOptions {
+  width?: string;
+  height?: string;
+  maxWidth?: string;
+  maxHeight?: string;
 }
 
+/**
+ * @docalias HTMLElement|{name: string, tab?: string}|Surface|{drawArea:
+ * HTMLElement}
+ */
 export type Drawable = HTMLElement|Surface|SurfaceInfo|{
   drawArea: HTMLElement;
 };
@@ -103,31 +106,95 @@ export function isSurface(drawable: Drawable): drawable is Surface {
  * Common visualisation options for '.render' functions.
  */
 export interface VisOptions {
+  /**
+   * Width of chart in px
+   */
   width?: number;
+  /**
+   * Height of chart in px
+   */
   height?: number;
+  /**
+   * Label for xAxis
+   */
   xLabel?: string;
+  /**
+   * Label for yAxis
+   */
   yLabel?: string;
-  xType?: 'quantitative'|'ordinal'|'nominal';
-  yType?: 'quantitative'|'ordinal'|'nominal';
+  /**
+   * Fontsize in px
+   */
   fontSize?: number;
+  /**
+   * Will be set automatically
+   */
+  xType?: 'quantitative'|'ordinal'|'nominal';
+  /**
+   * Will be set automatically
+   */
+  yType?: 'quantitative'|'ordinal'|'nominal';
 }
 
 /**
  * Options for XY plots
  */
 export interface XYPlotOptions extends VisOptions {
+  /**
+   * domain of the x axis. Overriden by zoomToFit
+   */
   xAxisDomain?: [number, number];
+  /**
+   * domain of the y axis. Overriden by zoomToFit
+   */
   yAxisDomain?: [number, number];
+  /**
+   * Set the chart bounds to just fit the data. This may modify the axis scales
+   * but allows fitting more data into view.
+   */
   zoomToFit?: boolean;
+}
+
+/**
+ * Data format for XY plots
+ */
+export interface XYPlotData {
+  /**
+   * An array (or nested array) of {x, y} tuples.
+   */
+  values: Point2D[][]|Point2D[];
+  /**
+   * Series names/labels
+   */
+  series?: string[];
 }
 
 /**
  * Histogram options.
  */
-export type HistogramOpts = VisOptions&{
+export interface HistogramOpts extends VisOptions {
+  /**
+   * By default a histogram will also compute and display summary statistics.
+   * If stats is set to false then summary statistics will not be displayed.
+   *
+   * Pre computed stats can also be passed in and should have the following
+   * format:
+   *  {
+   *    numVals?: number,
+   *    min?: number,
+   *    max?: number,
+   *    numNans?: number,
+   *    numZeros?: number,
+   *    numInfs?: number,
+   *  }
+   */
   stats?: HistogramStats|false;
+
+  /**
+   * Maximum number of bins in histogram.
+   */
   maxBins?: number;
-};
+}
 
 /**
  * Summary statistics for histogram.
@@ -148,40 +215,94 @@ export type TypedArray = Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|
     Uint32Array|Uint8ClampedArray|Float32Array|Float64Array;
 
 /**
- * Data format for confusion matrix
+ * An object with a 'values' property and a 'labels' property.
  */
 export interface ConfusionMatrixData {
+  /**
+   * a square matrix of numbers representing counts for each (label, prediction)
+   * pair
+   */
   values: number[][];
+
+  /**
+   * Human readable labels for each class in the matrix. Optional
+   */
   tickLabels?: string[];
+}
+
+export interface ConfusionMatrixOptions extends VisOptions {
+  /**
+   * Color cells on the diagonal. Defaults to true
+   */
+  shadeDiagonal?: boolean;
+  /**
+   * render the values of each cell as text. Defaults to true
+   */
+  showTextOverlay?: boolean;
 }
 
 /**
  * Datum format for scatter and line plots
  */
-export type Point2D = {
-  x: number; y: number;
-};
+export interface Point2D {
+  x: number;
+  y: number;
+}
 
 /**
- * Data format for confusion matrix
+ *  An object with a 'values' property and a 'labels' property.
  */
 export interface HeatmapData {
+  /**
+   * Matrix of values in column-major order.
+   */
   values: number[][]|Tensor2D;
+  /**
+   * x axis tick labels
+   */
   xTickLabels?: string[];
+  /**
+   * y axis tick labels
+   */
   yTickLabels?: string[];
 }
 
 /**
  * Color map names.
- *
- * Currently supported by heatmap
  */
+/** @docinline */
 export type NamedColorMap = 'greyscale'|'viridis'|'blues';
 
 /**
  * Visualization options for Heatmap
  */
 export interface HeatmapOptions extends VisOptions {
+  /**
+   * Defaults to viridis
+   */
   colorMap?: NamedColorMap;
+
+  /**
+   * Custom output domain for the color scale.
+   * Useful if you want to plot multiple heatmaps using the same scale.
+   */
   domain?: number[];
+}
+
+/**
+ * Data format for render.table
+ */
+export interface TableData {
+  /**
+   * Column names
+   */
+  headers: string[];
+
+  /**
+   * An array of arrays (one for  each row). The inner
+   * array length usually matches the length of data.headers.
+   *
+   * Typically the values are numbers or strings.
+   */
+  values: number[][]|string[][];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,5 +304,6 @@ export interface TableData {
    *
    * Typically the values are numbers or strings.
    */
-  values: number[][]|string[][];
+  // tslint:disable-next-line:no-any
+  values: any[][];
 }


### PR DESCRIPTION
Update the types used in various functions and a lot of the jsdoc comments (many doc comments move to interface definitions so they can be shared). The primary goal of this is to improve the rendering of vis docs on the website.

preview of effect:

__before__
<img width="829" alt="Screen Shot 2019-05-01 at 11 23 06 AM" src="https://user-images.githubusercontent.com/26408/57025065-28b30280-6c04-11e9-8945-07ae907d9899.png">

__after__
<img width="802" alt="Screen Shot 2019-05-01 at 11 23 13 AM" src="https://user-images.githubusercontent.com/26408/57025096-39637880-6c04-11e9-9313-65260acbdca7.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/73)
<!-- Reviewable:end -->
