### PR TITLE
support row major order in heatmap

### DIFF
--- a/src/render/heatmap.ts
+++ b/src/render/heatmap.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {Tensor} from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs';
 import embed, {Mode, VisualizationSpec} from 'vega-embed';
 
 import {Drawable, HeatmapData, HeatmapOptions} from '../types';
@@ -64,6 +64,31 @@ export async function heatmap(
   const options = Object.assign({}, defaultOpts, opts);
   const drawArea = getDrawArea(container);
 
+  let inputValues = data.values;
+  if (options.rowMajor) {
+    let originalShape: number[];
+    if (inputValues instanceof tf.Tensor) {
+      originalShape = inputValues.shape;
+      inputValues = inputValues.transpose();
+    } else {
+      originalShape = [inputValues.length, inputValues[0].length];
+      inputValues =
+          tf.tidy(() => tf.tensor2d(inputValues as number[][]).transpose());
+    }
+    // In either case we have created a new tensor, download the values and
+    // dispose that tensor here.
+    const transposedTensor = inputValues;
+    inputValues = await transposedTensor.array();
+    transposedTensor.dispose();
+
+    const transposedShape = [inputValues.length, inputValues[0].length];
+    tf.util.assert(
+        originalShape[0] === transposedShape[1] &&
+            originalShape[1] === transposedShape[0],
+        () => `Unexpected transposed shape. Original ${
+            originalShape} : Transposed ${transposedShape}`);
+  }
+
   // Format data for vega spec; an array of objects, one for for each cell
   // in the matrix.
   const values: MatrixEntry[] = [];
@@ -71,12 +96,12 @@ export async function heatmap(
 
   // These two branches are very similar but we want to do the test once
   // rather than on every element access
-  if (data.values instanceof Tensor) {
+  if (inputValues instanceof tf.Tensor) {
     assert(
-        data.values.rank === 2,
+        inputValues.rank === 2,
         'Input to renderHeatmap must be a 2d array or Tensor2d');
 
-    const shape = data.values.shape;
+    const shape = inputValues.shape;
     if (xTickLabels) {
       assert(
           shape[0] === xTickLabels.length,
@@ -96,7 +121,7 @@ export async function heatmap(
     // This is a slightly specialized version of TensorBuffer.get, inlining it
     // avoids the overhead of a function call per data element access and is
     // specialized to only deal with the 2d case.
-    const inputArray = await data.values.data();
+    const inputArray = await inputValues.data();
     const [numRows, numCols] = shape;
 
     for (let row = 0; row < numRows; row++) {
@@ -113,18 +138,18 @@ export async function heatmap(
   } else {
     if (xTickLabels) {
       assert(
-          data.values.length === xTickLabels.length,
-          `Number of rows (${data.values.length}) must match
+          inputValues.length === xTickLabels.length,
+          `Number of rows (${inputValues.length}) must match
           number of xTickLabels (${xTickLabels.length})`);
     }
 
-    const inputArray = data.values as number[][];
+    const inputArray = inputValues as number[][];
     for (let row = 0; row < inputArray.length; row++) {
       const x = xTickLabels ? xTickLabels[row] : row;
       if (yTickLabels) {
         assert(
-            data.values[row].length === yTickLabels.length,
-            `Number of columns in row ${row} (${data.values[row].length})
+            inputValues[row].length === yTickLabels.length,
+            `Number of columns in row ${row} (${inputValues[row].length})
             must match length of yTickLabels (${yTickLabels.length})`);
       }
       for (let col = 0; col < inputArray[row].length; col++) {
@@ -229,6 +254,7 @@ const defaultOpts = {
   colorMap: 'viridis',
   fontSize: 12,
   domain: null,
+  rowMajor: false,
 };
 
 interface MatrixEntry {

--- a/src/render/heatmap_test.ts
+++ b/src/render/heatmap_test.ts
@@ -40,6 +40,17 @@ describe('renderHeatmap', () => {
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
   });
 
+  it('renders a chart with rowMajor=true', async () => {
+    const data: HeatmapData = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20], [8, 2, 8]],
+    };
+
+    const container = document.getElementById('container') as HTMLElement;
+    await heatmap(container, data, {rowMajor: true});
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+  });
+
   it('renders a chart with a tensor', async () => {
     const values = tf.tensor2d([[4, 2, 8], [1, 7, 2], [3, 3, 20]]);
     const data: HeatmapData = {

--- a/src/render/heatmap_test.ts
+++ b/src/render/heatmap_test.ts
@@ -45,10 +45,33 @@ describe('renderHeatmap', () => {
       values: [[4, 2, 8], [1, 7, 2], [3, 3, 20], [8, 2, 8]],
     };
 
+    const numTensorsBefore = tf.memory().numTensors;
+
     const container = document.getElementById('container') as HTMLElement;
     await heatmap(container, data, {rowMajor: true});
 
+    const numTensorsAfter = tf.memory().numTensors;
+
     expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+    expect(numTensorsAfter).toEqual(numTensorsBefore);
+  });
+
+  it('renders a chart with rowMajor=true and custom labels', async () => {
+    const data: HeatmapData = {
+      values: [[4, 2, 8], [1, 7, 2], [3, 3, 20], [8, 2, 8]],
+      xTickLabels: ['alpha', 'beta', 'gamma'],
+      yTickLabels: ['first', 'second', 'third', 'fourth'],
+    };
+
+    const numTensorsBefore = tf.memory().numTensors;
+
+    const container = document.getElementById('container') as HTMLElement;
+    await heatmap(container, data, {rowMajor: true});
+
+    const numTensorsAfter = tf.memory().numTensors;
+
+    expect(document.querySelectorAll('.vega-embed').length).toBe(1);
+    expect(numTensorsAfter).toEqual(numTensorsBefore);
   });
 
   it('renders a chart with a tensor', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,6 +255,8 @@ export interface Point2D {
 export interface HeatmapData {
   /**
    * Matrix of values in column-major order.
+   *
+   * Row major order is supported by setting a boolean in options
    */
   values: number[][]|Tensor2D;
   /**
@@ -287,6 +289,13 @@ export interface HeatmapOptions extends VisOptions {
    * Useful if you want to plot multiple heatmaps using the same scale.
    */
   domain?: number[];
+
+  /**
+   * Pass in data values in row-major order.
+   *
+   * Internally this will transpose the data values before rendering.
+   */
+  rowMajor?: boolean;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -256,7 +256,7 @@ export interface HeatmapData {
   /**
    * Matrix of values in column-major order.
    *
-   * Row major order is supported by setting a boolean in options
+   * Row major order is supported by setting a boolean in options.
    */
   values: number[][]|Tensor2D;
   /**


### PR DESCRIPTION
Addresses https://github.com/tensorflow/tfjs/issues/1543

Note that the docs were clarified in a previous PR, but this PR adds support for row major order to heatmap, which i think is quite reasonable. PTAL and also see if the docs are overall clearer. Note that param docs are now in types.ts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-vis/74)
<!-- Reviewable:end -->
